### PR TITLE
Implement CommitBlocker

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -317,6 +317,10 @@ func (app *BaseApp) Commit() (res abci.ResponseCommit) {
 	// empty/reset the deliver state
 	app.deliverState = nil
 
+	if app.commitBlocker != nil {
+		app.commitBlocker(app.checkState.ctx)
+	}
+
 	var halt bool
 
 	switch {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -59,13 +59,14 @@ type BaseApp struct { // nolint: maligned
 	interfaceRegistry types.InterfaceRegistry
 	txDecoder         sdk.TxDecoder // unmarshal []byte into sdk.Tx
 
-	anteHandler    sdk.AnteHandler  // ante handler for fee and auth
-	initChainer    sdk.InitChainer  // initialize state with validators and state blob
-	beginBlocker   sdk.BeginBlocker // logic to run before any txs
-	endBlocker     sdk.EndBlocker   // logic to run after all txs, and to determine valset changes
-	addrPeerFilter sdk.PeerFilter   // filter peers by address and port
-	idPeerFilter   sdk.PeerFilter   // filter peers by node ID
-	fauxMerkleMode bool             // if true, IAVL MountStores uses MountStoresDB for simulation speed.
+	anteHandler    sdk.AnteHandler   // ante handler for fee and auth
+	initChainer    sdk.InitChainer   // initialize state with validators and state blob
+	beginBlocker   sdk.BeginBlocker  // logic to run before any txs
+	commitBlocker  sdk.CommitBlocker // logic to run during commit
+	endBlocker     sdk.EndBlocker    // logic to run after all txs, and to determine valset changes
+	addrPeerFilter sdk.PeerFilter    // filter peers by address and port
+	idPeerFilter   sdk.PeerFilter    // filter peers by node ID
+	fauxMerkleMode bool              // if true, IAVL MountStores uses MountStoresDB for simulation speed.
 
 	// manages snapshots, i.e. dumps of app state at certain intervals
 	snapshotManager    *snapshots.Manager

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -145,6 +145,14 @@ func (app *BaseApp) SetBeginBlocker(beginBlocker sdk.BeginBlocker) {
 	app.beginBlocker = beginBlocker
 }
 
+func (app *BaseApp) SetCommitBlocker(commitBlocker sdk.CommitBlocker) {
+	if app.sealed {
+		panic("SetCommitBlocker() on sealed BaseApp")
+	}
+
+	app.commitBlocker = commitBlocker
+}
+
 func (app *BaseApp) SetEndBlocker(endBlocker sdk.EndBlocker) {
 	if app.sealed {
 		panic("SetEndBlocker() on sealed BaseApp")

--- a/types/abci.go
+++ b/types/abci.go
@@ -19,3 +19,7 @@ type EndBlocker func(ctx Context, req abci.RequestEndBlock) abci.ResponseEndBloc
 
 // PeerFilter responds to p2p filtering queries from Tendermint
 type PeerFilter func(info string) abci.ResponseQuery
+
+// CommitBlocker runs code during commit after the block number has been incremented and the `checkState` has been
+// branched for the new block.
+type CommitBlocker func(ctx Context)


### PR DESCRIPTION
Add `CommitBlocker`, which allows for notifying the application when the ABCI `Commit` call occurs. The callback is invoked using the newly branched `checkState` of the next block.