### PR TITLE
Enable CI workflows and fix failures

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -84,7 +84,7 @@ jobs:
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ false }} # Disabled due to requiring Slack integration
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest
-    if: ${{ failure() }}
+    if: ${{ false }} # Disabled due to requiring Slack integration
     steps:
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,7 @@ jobs:
           path: ./tests/e2e-profile.out
 
   repo-analysis:
+    if: ${{ false }} # Disabled due to requiring SonarCloud integration
     runs-on: ubuntu-latest
     needs: [tests, test-integration, test-e2e]
     steps:

--- a/server/util.go
+++ b/server/util.go
@@ -146,11 +146,12 @@ func InterceptConfigsPreRunHandler(cmd *cobra.Command, customAppConfigTemplate s
 	}
 
 	var logger tmlog.Logger
-	if config.LogFormat == tmcfg.LogFormatJSON {
+	switch config.LogFormat {
+	case tmcfg.LogFormatJSON:
 		logger = tmlog.NewTMJSONLogger(tmlog.NewSyncWriter(os.Stdout))
-	} else if config.LogFormat == tmcfg.LogFormatPlain {
+	case tmcfg.LogFormatPlain:
 		logger = tmlog.NewTMLogger(tmlog.NewSyncWriter(os.Stdout))
-	} else {
+	default:
 		return errors.New("unsupported log format")
 	}
 


### PR DESCRIPTION
This PR enables workflows in CI for our `cosmos-sdk` fork and fixes failures.

Many of the actions weren't being run due to our GitHub security settings. So I needed to whitelist a number of workflows to get them to run. So this is why nothing was running in previous PRs.

Once I whitelisted the necessary workflows, I noticed these issues, which is what I fixed in this PR.