### PR TITLE
Only run sonarcloud if we have a token, allows for green test signal on simulation tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -178,7 +178,7 @@ jobs:
           name: "${{ github.sha }}-e2e-coverage"
         continue-on-error: true
       - name: sonarcloud
-        if: env.GIT_DIFF
+        if: env.GIT_DIFF && secrets.SONAR_TOKEN
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -266,7 +266,7 @@ jobs:
           cd simapp
           go test -mod=readonly -timeout 30m -tags='app_v1 norace ledger test_ledger_mock rocksdb_build' ./...
       - name: sonarcloud
-        if: env.GIT_DIFF
+        if: env.GIT_DIFF && secrets.SONAR_TOKEN
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
See an example [run here](https://github.com/dydxprotocol/cosmos-sdk/actions/runs/4832725153/jobs/8611863959) that fails because of the missing token