### PR TITLE
[CORE-206] change default commision rate and default commission max rate to 100%

### DIFF
--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -25,8 +25,8 @@ import (
 var (
 	DefaultTokens                  = sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
 	defaultAmount                  = DefaultTokens.String() + sdk.DefaultBondDenom
-	defaultCommissionRate          = "0.1"
-	defaultCommissionMaxRate       = "0.2"
+	defaultCommissionRate          = "1"
+	defaultCommissionMaxRate       = "1"
 	defaultCommissionMaxChangeRate = "0.01"
 	defaultMinSelfDelegation       = "1"
 )


### PR DESCRIPTION
Make `dydxprotocol gentx` initialize the validator commission rate to 100% by default. Validator can pass in an alternative amount as part of their gentx config. 
