### PR TITLE
Upgrade CosmosSDK to the v0.47.4 release version

### DIFF
--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -88,7 +88,7 @@ jobs:
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest
-    if: ${{ success() }}
+    if: ${{ false }} # Disabled due to requiring Slack integration
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -116,7 +116,7 @@ jobs:
     needs:
       [test-sim-multi-seed-short, test-sim-after-import, test-sim-import-export]
     runs-on: ubuntu-latest
-    if: ${{ failure() }}
+    if: ${{ false }} # Disabled due to requiring Slack integration
     steps:
       - name: Notify Slack on failure
         uses: rtCamp/action-slack-notify@v2.2.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -142,6 +142,7 @@ jobs:
           path: ./tests/e2e-profile.out
 
   repo-analysis:
+    if: ${{ false }} # Disabled due to requiring SonarCloud integration
     runs-on: ubuntu-latest
     needs: [tests, test-integration, test-e2e]
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -182,7 +182,7 @@ jobs:
           name: "${{ github.sha }}-e2e-coverage"
         continue-on-error: true
       - name: sonarcloud
-        if: env.GIT_DIFF
+        if: env.GIT_DIFF && secrets.SONAR_TOKEN
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -273,7 +273,7 @@ jobs:
           cd simapp
           go test -mod=readonly -timeout 30m -tags='app_v1 norace ledger test_ledger_mock rocksdb_build' ./...
       - name: sonarcloud
-        if: env.GIT_DIFF
+        if: env.GIT_DIFF && secrets.SONAR_TOKEN
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ When a new version of CosmosSDK is published, we may want to adopt the changes i
 3. Push the new branch (i.e `dydx-fork-v0.47.0-alpha2`).
 4. Off of this new branch, create a new branch. (i.e `totoro/dydxCommits`)
 5. Cherry-pick each dydx-created commit from the current default branch, in order, on to the new `dydx-fork-$VERSION` branch (note: you may want to consider creating multiple PRs for this process if there are difficulties or merge conflicts). For example, `git cherry-pick <commit hash>`. You can verify the first commit by seeing the most recent commit sha for the `$VERSION` (i.e `v0.47.0-alpha2`) tag on the `cosmos/cosmos-sdk` repo, and taking the next commit from that sha.
-6. Open a PR to merge the second branch (`totoro/dydxCommits`) into the first (`dydx-fork-v0.47.0-alpha2`). Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
-7. Update `dydxprotocol/v4` by following the steps in "Making Changes to the fork" above.
-8. Set `dydx-fork-$VERSION` as the [default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch) in this repository.
+6. The dYdX fork uses an optimized version of `runTx` for handling ABCI CheckTx messages. Ensure that the logic within `runCheckTxConcurrently` stays up to date with the `runTx` counterpart by diffing [baseapp.go#runTx](https://github.com/dydxprotocol/cosmos-sdk/blob/6477dcf5693422fef693432e29bd979709aa995d/baseapp/baseapp.go#L754) current version against the new version copying over relevant changes to [baseapp.go#runCheckTxConcurrently](https://github.com/dydxprotocol/cosmos-sdk/blob/6477dcf5693422fef693432e29bd979709aa995d/baseapp/baseapp.go#L619).
+7. Open a PR to merge the second branch (`totoro/dydxCommits`) into the first (`dydx-fork-v0.47.0-alpha2`). Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
+8. Update `dydxprotocol/v4` by following the steps in "Making Changes to the fork" above.
+9. Set `dydx-fork-$VERSION` as the [default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch) in this repository.
 
 Note that the github CI workflows need permissioning. If they fail with a permissioning error, i.e `Resource not accessible through integration`, a Github admin will need to whitelist the workflow.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
+# dYdX Fork of CosmosSDK
+
+This is a lightweight fork of CosmosSDK. The current version of the forked code resides on the [default branch](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#about-the-default-branch).
+
+## Making Changes to the Fork
+
+1. Open a PR against the current default branch (i.e. `dydx-fork-v0.47.0-alpha2`).
+2. Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
+3. After merging, update the `v4` repository's `go.mod`, and `go.sum` files with your merged `$COMMIT_HASH`.
+4. (In `dydxprotocol/v4`) `go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/dydxprotocol/cosmos-sdk@$COMMIT_HASH`
+5. (In `dydxprotocol/v4`) `go mod tidy`
+6. (In `dydxprotocol/v4`) update package references in `mocks/Makefile`. See [here](https://github.com/dydxprotocol/v4/pull/848) for an example.
+7. Open a PR in `dydxprotocol/v4` to bump the version of the fork.
+
+## Fork maintenance
+
+We'd like to keep the `main` branch up to date with `cosmos/cosmos-sdk`. You can utilize GitHub's [sync fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) button to accomplish this. ⚠️ Please only use this on the `main` branch, not on the fork branches as it will discard our commits.⚠️
+
+Before these steps, please set the `upstream` remote to be the `cosmos/cosmos-sdk` repo. If you use http auth, you will have to switch the upstream url to be http.
+`git remote add upstream git@github.com:cosmos/cosmos-sdk.git`
+
+Note that this doesn't pull in upstream tags, so in order to do this follow these steps:
+1. `git fetch upstream`
+2. `git push --tags`
+
+## Updating CosmosSDK to new versions
+
+When a new version of CosmosSDK is published, we may want to adopt the changes in our fork. This process can be somewhat tedious, but below are the recommended steps to accomplish this.
+
+1. Ensure the `main` branch and all tags are up to date by following the steps above in "Fork maintenance".
+2. Create a new branch off the desired CosmosSDK commit using tags. `git checkout -b dydx-fork-$VERSION <CosmosSDK repo's tag name>`. The new branch should be named something like `dydx-fork-$VERSION` where `$VERSION` is the version of CosmosSDK being forked (should match the CosmosSDK repo's tag name). i.e. `dydx-fork-v0.47.0-alpha2`.
+3. Push the new branch (i.e `dydx-fork-v0.47.0-alpha2`).
+4. Off of this new branch, create a new branch. (i.e `totoro/dydxCommits`)
+5. Cherry-pick each dydx-created commit from the current default branch, in order, on to the new `dydx-fork-$VERSION` branch (note: you may want to consider creating multiple PRs for this process if there are difficulties or merge conflicts). For example, `git cherry-pick <commit hash>`. You can verify the first commit by seeing the most recent commit sha for the `$VERSION` (i.e `v0.47.0-alpha2`) tag on the `cosmos/cosmos-sdk` repo, and taking the next commit from that sha.
+6. Open a PR to merge the second branch (`totoro/dydxCommits`) into the first (`dydx-fork-v0.47.0-alpha2`). Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
+7. Update `dydxprotocol/v4` by following the steps in "Making Changes to the fork" above.
+8. Set `dydx-fork-$VERSION` as the [default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch) in this repository.
+
+Note that the github CI workflows need permissioning. If they fail with a permissioning error, i.e `Resource not accessible through integration`, a Github admin will need to whitelist the workflow.
+
 <div align="center">
   <h1> Cosmos SDK </h1>
 </div>

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a lightweight fork of CosmosSDK. The current version of the forked code 
 
 ## Making Changes to the Fork
 
-1. Open a PR against the current default branch (i.e. `dydx-fork-v0.47.0-alpha2`).
+1. Open a PR against the current default branch (i.e. `dydx-fork-v0.47.4`).
 2. Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
 3. After merging, update the `v4` repository's `go.mod`, and `go.sum` files with your merged `$COMMIT_HASH`.
 4. (In `dydxprotocol/v4`) `go mod edit -replace github.com/cosmos/cosmos-sdk=github.com/dydxprotocol/cosmos-sdk@$COMMIT_HASH`
@@ -28,12 +28,12 @@ Note that this doesn't pull in upstream tags, so in order to do this follow thes
 When a new version of CosmosSDK is published, we may want to adopt the changes in our fork. This process can be somewhat tedious, but below are the recommended steps to accomplish this.
 
 1. Ensure the `main` branch and all tags are up to date by following the steps above in "Fork maintenance".
-2. Create a new branch off the desired CosmosSDK commit using tags. `git checkout -b dydx-fork-$VERSION <CosmosSDK repo's tag name>`. The new branch should be named something like `dydx-fork-$VERSION` where `$VERSION` is the version of CosmosSDK being forked (should match the CosmosSDK repo's tag name). i.e. `dydx-fork-v0.47.0-alpha2`.
-3. Push the new branch (i.e `dydx-fork-v0.47.0-alpha2`).
+2. Create a new branch off the desired CosmosSDK commit using tags. `git checkout -b dydx-fork-$VERSION <CosmosSDK repo's tag name>`. The new branch should be named something like `dydx-fork-$VERSION` where `$VERSION` is the version of CosmosSDK being forked (should match the CosmosSDK repo's tag name). i.e. `dydx-fork-v0.47.4`.
+3. Push the new branch (i.e `dydx-fork-v0.47.4`).
 4. Off of this new branch, create a new branch. (i.e `totoro/dydxCommits`)
-5. Cherry-pick each dydx-created commit from the current default branch, in order, on to the new `dydx-fork-$VERSION` branch (note: you may want to consider creating multiple PRs for this process if there are difficulties or merge conflicts). For example, `git cherry-pick <commit hash>`. You can verify the first commit by seeing the most recent commit sha for the `$VERSION` (i.e `v0.47.0-alpha2`) tag on the `cosmos/cosmos-sdk` repo, and taking the next commit from that sha.
+5. Cherry-pick each dydx-created commit from the current default branch, in order, on to the new `dydx-fork-$VERSION` branch (note: you may want to consider creating multiple PRs for this process if there are difficulties or merge conflicts). For example, `git cherry-pick <commit hash>`. You can verify the first commit by seeing the most recent commit sha for the `$VERSION` (i.e `v0.47.4`) tag on the `cosmos/cosmos-sdk` repo, and taking the next commit from that sha.
 6. The dYdX fork uses an optimized version of `runTx` for handling ABCI CheckTx messages. Ensure that the logic within `runCheckTxConcurrently` stays up to date with the `runTx` counterpart by diffing [baseapp.go#runTx](https://github.com/dydxprotocol/cosmos-sdk/blob/6477dcf5693422fef693432e29bd979709aa995d/baseapp/baseapp.go#L754) current version against the new version copying over relevant changes to [baseapp.go#runCheckTxConcurrently](https://github.com/dydxprotocol/cosmos-sdk/blob/6477dcf5693422fef693432e29bd979709aa995d/baseapp/baseapp.go#L619).
-7. Open a PR to merge the second branch (`totoro/dydxCommits`) into the first (`dydx-fork-v0.47.0-alpha2`). Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
+7. Open a PR to merge the second branch (`totoro/dydxCommits`) into the first (`dydx-fork-v0.47.4`). Get approval, and merge. *DO NOT SQUASH AND MERGE. PLEASE REBASE AND MERGE*
 8. Update `dydxprotocol/v4` by following the steps in "Making Changes to the fork" above.
 9. Set `dydx-fork-$VERSION` as the [default branch](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/changing-the-default-branch) in this repository.
 

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -372,9 +372,6 @@ func (app *BaseApp) ProcessProposal(req abci.RequestProcessProposal) (resp abci.
 // will contain relevant error information. Regardless of tx execution outcome,
 // the ResponseCheckTx will contain relevant gas execution context.
 func (app *BaseApp) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
-	app.mtx.Lock()
-	defer app.mtx.Unlock()
-
 	var mode runTxMode
 
 	switch {
@@ -388,7 +385,7 @@ func (app *BaseApp) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 		panic(fmt.Sprintf("unknown RequestCheckTx type: %s", req.Type))
 	}
 
-	gInfo, result, anteEvents, priority, err := app.runTx(mode, req.Tx)
+	gInfo, result, anteEvents, priority, err := app.runCheckTxConcurrently(mode, req.Tx)
 	if err != nil {
 		return sdkerrors.ResponseCheckTxWithEvents(err, gInfo.GasWanted, gInfo.GasUsed, anteEvents, app.trace)
 	}

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -466,6 +466,10 @@ func (app *BaseApp) Commit() abci.ResponseCommit {
 	// empty/reset the deliver state
 	app.deliverState = nil
 
+	if app.commiter != nil {
+		app.commiter(app.checkState.ctx)
+	}
+
 	var halt bool
 
 	switch {

--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -71,6 +71,16 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 		app.StoreConsensusParams(app.deliverState.ctx, req.ConsensusParams)
 	}
 
+	defer func() {
+		// InitChain represents the state of the application BEFORE the first block,
+		// i.e. the genesis block. This means that when processing the app's InitChain
+		// handler, the block height is zero by default. However, after Commit is called
+		// the height needs to reflect the true block height.
+		initHeader.Height = req.InitialHeight
+		app.checkState.ctx = app.checkState.ctx.WithBlockHeader(initHeader)
+		app.deliverState.ctx = app.deliverState.ctx.WithBlockHeader(initHeader)
+	}()
+
 	if app.initChainer == nil {
 		return
 	}
@@ -113,8 +123,8 @@ func (app *BaseApp) InitChain(req abci.RequestInitChain) (res abci.ResponseInitC
 		appHash = emptyHash[:]
 	}
 
-	// NOTE: We don't commit, but BeginBlock for block `initial_height` starts from this
-	// deliverState.
+	// NOTE: We don't commit, but BeginBlock for block InitialHeight starts from
+	// this deliverState.
 	return abci.ResponseInitChain{
 		ConsensusParams: res.ConsensusParams,
 		Validators:      res.Validators,

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -596,6 +596,33 @@ func TestABCI_EndBlock(t *testing.T) {
 	require.Equal(t, cp.Block.MaxGas, res.ConsensusParamUpdates.Block.MaxGas)
 }
 
+func TestBaseApp_Commit(t *testing.T) {
+	db := dbm.NewMemDB()
+	name := t.Name()
+	logger := defaultLogger()
+
+	cp := &tmproto.ConsensusParams{
+		Block: &tmproto.BlockParams{
+			MaxGas: 5000000,
+		},
+	}
+
+	app := baseapp.NewBaseApp(name, logger, db, nil)
+	app.SetParamStore(&paramStore{db: dbm.NewMemDB()})
+	app.InitChain(abci.RequestInitChain{
+		ConsensusParams: cp,
+	})
+
+	wasCommiterCalled := false
+	app.SetCommiter(func(ctx sdk.Context) {
+		wasCommiterCalled = true
+	})
+	app.Seal()
+
+	app.Commit()
+	require.Equal(t, true, wasCommiterCalled)
+}
+
 func TestABCI_CheckTx(t *testing.T) {
 	// This ante handler reads the key and checks that the value matches the
 	// current counter. This ensures changes to the KVStore persist across
@@ -1318,6 +1345,28 @@ func TestABCI_GetBlockRetentionHeight(t *testing.T) {
 			require.Equal(t, tc.expected, tc.bapp.GetBlockRetentionHeight(tc.commitHeight))
 		})
 	}
+}
+
+// Verifies that the Commiter is called with the checkState.
+func TestCommiterCalledWithCheckState(t *testing.T) {
+	t.Parallel()
+
+	logger := defaultLogger()
+	db := dbm.NewMemDB()
+	name := t.Name()
+	app := baseapp.NewBaseApp(name, logger, db, nil)
+
+	wasCommiterCalled := false
+	app.SetCommiter(func(ctx sdk.Context) {
+		// Make sure context is for next block
+		require.Equal(t, true, ctx.IsCheckTx())
+		wasCommiterCalled = true
+	})
+
+	app.BeginBlock(abci.RequestBeginBlock{Header: tmproto.Header{Height: 1}})
+	app.Commit()
+
+	require.Equal(t, true, wasCommiterCalled)
 }
 
 func TestABCI_Proposal_HappyPath(t *testing.T) {

--- a/baseapp/abci_test.go
+++ b/baseapp/abci_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cometbft/cometbft-db"
 	"github.com/cosmos/gogoproto/jsonpb"
 	"github.com/stretchr/testify/require"
 
@@ -37,6 +37,21 @@ func TestABCI_Info(t *testing.T) {
 	require.Equal(t, int64(0), res.LastBlockHeight)
 	require.Equal(t, []uint8(nil), res.LastBlockAppHash)
 	require.Equal(t, suite.baseApp.AppVersion(), res.AppVersion)
+}
+
+func TestABCI_First_block_Height(t *testing.T) {
+	suite := NewBaseAppSuite(t, baseapp.SetChainID("test-chain-id"))
+	app := suite.baseApp
+
+	app.InitChain(abci.RequestInitChain{
+		ChainId:         "test-chain-id",
+		ConsensusParams: &cmtproto.ConsensusParams{Block: &cmtproto.BlockParams{MaxGas: 5000000}},
+		InitialHeight:   1,
+	})
+	_ = app.Commit()
+
+	ctx := app.GetContextForCheckTx(nil)
+	require.Equal(t, int64(1), ctx.BlockHeight())
 }
 
 func TestABCI_InitChain(t *testing.T) {

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -68,6 +68,7 @@ type BaseApp struct { //nolint: maligned
 	processProposal sdk.ProcessProposalHandler // the handler which runs on ABCI ProcessProposal
 	prepareProposal sdk.PrepareProposalHandler // the handler which runs on ABCI PrepareProposal
 	endBlocker      sdk.EndBlocker             // logic to run after all txs, and to determine valset changes
+	commiter        sdk.Commiter               // logic to run during commit
 	addrPeerFilter  sdk.PeerFilter             // filter peers by address and port
 	idPeerFilter    sdk.PeerFilter             // filter peers by node ID
 	fauxMerkleMode  bool                       // if true, IAVL MountStores uses MountStoresDB for simulation speed.

--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 
 	dbm "github.com/cometbft/cometbft-db"
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -145,6 +146,9 @@ type BaseApp struct { //nolint: maligned
 	abciListeners []ABCIListener
 
 	chainID string
+
+	// Used to synchronize the application when using an unsynchronized ABCI++ client.
+	mtx sync.Mutex
 }
 
 // NewBaseApp returns a reference to an initialized BaseApp. It accepts a

--- a/baseapp/baseapp_test.go
+++ b/baseapp/baseapp_test.go
@@ -391,6 +391,9 @@ func TestBaseAppOptionSeal(t *testing.T) {
 		suite.baseApp.SetEndBlocker(nil)
 	})
 	require.Panics(t, func() {
+		suite.baseApp.SetCommiter(nil)
+	})
+	require.Panics(t, func() {
 		suite.baseApp.SetAnteHandler(nil)
 	})
 	require.Panics(t, func() {

--- a/baseapp/options.go
+++ b/baseapp/options.go
@@ -166,6 +166,14 @@ func (app *BaseApp) SetEndBlocker(endBlocker sdk.EndBlocker) {
 	app.endBlocker = endBlocker
 }
 
+func (app *BaseApp) SetCommiter(commiter sdk.Commiter) {
+	if app.sealed {
+		panic("SetCommiter() on sealed BaseApp")
+	}
+
+	app.commiter = commiter
+}
+
 func (app *BaseApp) SetAnteHandler(ah sdk.AnteHandler) {
 	if app.sealed {
 		panic("SetAnteHandler() on sealed BaseApp")

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -53,3 +53,7 @@ func (app *BaseApp) NewUncachedContext(isCheckTx bool, header tmproto.Header) sd
 func (app *BaseApp) GetContextForDeliverTx(txBytes []byte) sdk.Context {
 	return app.getContextForTx(runTxModeDeliver, txBytes)
 }
+
+func (app *BaseApp) GetContextForCheckTx(txBytes []byte) sdk.Context {
+	return app.getContextForTx(runTxModeCheck, txBytes)
+}

--- a/baseapp/test_helpers.go
+++ b/baseapp/test_helpers.go
@@ -16,7 +16,7 @@ func (app *BaseApp) SimCheck(txEncoder sdk.TxEncoder, tx sdk.Tx) (sdk.GasInfo, *
 	if err != nil {
 		return sdk.GasInfo{}, nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "%s", err)
 	}
-	gasInfo, result, _, _, err := app.runTx(runTxModeCheck, bz)
+	gasInfo, result, _, _, err := app.runCheckTxConcurrently(runTxModeCheck, bz)
 	return gasInfo, result, err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -197,3 +197,5 @@ retract (
 	// do not use
 	v0.43.0
 )
+
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078

--- a/go.sum
+++ b/go.sum
@@ -308,8 +308,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.37.2 h1:XB0yyHGT0lwmJlFmM4+rsRnczPlHoAKFX6K8Zgc2/Jc=
-github.com/cometbft/cometbft v0.37.2/go.mod h1:Y2MMMN//O5K4YKd8ze4r9jmk4Y7h0ajqILXbH5JQFVs=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=
@@ -378,6 +376,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078 h1:gIBKK/wL+OTnMAEX8ZI3pxjGKq5nOHHoeGoMdk+3xR4=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/runtime/module.go
+++ b/runtime/module.go
@@ -136,8 +136,10 @@ func ProvideMemoryStoreKey(key depinject.ModuleKey, app *AppBuilder) *storetypes
 	return storeKey
 }
 
-func ProvideDeliverTx(appBuilder *AppBuilder) func(abci.RequestDeliverTx) abci.ResponseDeliverTx {
-	return func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
-		return appBuilder.app.BaseApp.DeliverTx(tx)
+// We modify this method explicitly to require an additional parameter so that any additional usages
+// will be audited to ensure that the usage of the function is already holding the baseapp mutex lock.
+func ProvideDeliverTx(appBuilder *AppBuilder) func(abci.RequestDeliverTx, bool) abci.ResponseDeliverTx {
+	return func(tx abci.RequestDeliverTx, needsLock bool) abci.ResponseDeliverTx {
+		return appBuilder.app.BaseApp.DeliverTxShouldLock(tx, needsLock)
 	}
 }

--- a/server/start.go
+++ b/server/start.go
@@ -321,7 +321,7 @@ func startInProcess(ctx *Context, clientCtx client.Context, appCreator types.App
 			cfg,
 			pvm.LoadOrGenFilePV(cfg.PrivValidatorKeyFile(), cfg.PrivValidatorStateFile()),
 			nodeKey,
-			proxy.NewLocalClientCreator(app),
+			proxy.NewUnsynchronizedLocalClientCreator(app),
 			genDocProvider,
 			node.DefaultDBProvider,
 			node.DefaultMetricsProvider(cfg.Instrumentation),

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -396,7 +396,7 @@ func NewSimApp(
 	// must be passed by reference here.
 	app.ModuleManager = module.NewManager(
 		genutil.NewAppModule(
-			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTx,
+			app.AccountKeeper, app.StakingKeeper, app.BaseApp.DeliverTxShouldLock,
 			encodingConfig.TxConfig,
 		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, authsims.RandomGenesisAccounts, app.GetSubspace(authtypes.ModuleName)),

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -176,3 +176,5 @@ replace (
 	// replace broken goleveldb
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
+
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -307,8 +307,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.37.2 h1:XB0yyHGT0lwmJlFmM4+rsRnczPlHoAKFX6K8Zgc2/Jc=
-github.com/cometbft/cometbft v0.37.2/go.mod h1:Y2MMMN//O5K4YKd8ze4r9jmk4Y7h0ajqILXbH5JQFVs=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=
@@ -376,6 +374,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078 h1:gIBKK/wL+OTnMAEX8ZI3pxjGKq5nOHHoeGoMdk+3xR4=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/telemetry/wrapper.go
+++ b/telemetry/wrapper.go
@@ -11,6 +11,7 @@ const (
 	MetricKeyBeginBlocker = "begin_blocker"
 	MetricKeyEndBlocker   = "end_blocker"
 	MetricLabelNameModule = "module"
+	MetricKeyCommit       = "commit"
 )
 
 // NewLabel creates a new instance of Label with name and value

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -177,3 +177,5 @@ replace (
 	// TODO Remove it: https://github.com/cosmos/cosmos-sdk/issues/10409
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.0
 )
+
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -307,8 +307,6 @@ github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:z
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.37.2 h1:XB0yyHGT0lwmJlFmM4+rsRnczPlHoAKFX6K8Zgc2/Jc=
-github.com/cometbft/cometbft v0.37.2/go.mod h1:Y2MMMN//O5K4YKd8ze4r9jmk4Y7h0ajqILXbH5JQFVs=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=
@@ -376,6 +374,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078 h1:gIBKK/wL+OTnMAEX8ZI3pxjGKq5nOHHoeGoMdk+3xR4=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=

--- a/tests/integration/genutil/gentx_test.go
+++ b/tests/integration/genutil/gentx_test.go
@@ -293,13 +293,13 @@ func (suite *GenTxTestSuite) TestDeliverGenTxs() {
 			if tc.expPass {
 				suite.Require().NotPanics(func() {
 					genutil.DeliverGenTxs(
-						suite.ctx, genTxs, suite.stakingKeeper, suite.baseApp.DeliverTx,
+						suite.ctx, genTxs, suite.stakingKeeper, suite.baseApp.DeliverTxShouldLock,
 						suite.encodingConfig.TxConfig,
 					)
 				})
 			} else {
 				_, err := genutil.DeliverGenTxs(
-					suite.ctx, genTxs, suite.stakingKeeper, suite.baseApp.DeliverTx,
+					suite.ctx, genTxs, suite.stakingKeeper, suite.baseApp.DeliverTxShouldLock,
 					suite.encodingConfig.TxConfig,
 				)
 

--- a/testutil/mock/types_module_module.go
+++ b/testutil/mock/types_module_module.go
@@ -879,3 +879,116 @@ func (mr *MockEndBlockAppModuleMockRecorder) RegisterLegacyAminoCodec(arg0 inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterLegacyAminoCodec", reflect.TypeOf((*MockEndBlockAppModule)(nil).RegisterLegacyAminoCodec), arg0)
 }
+
+// MockCommitAppModule is a mock of CommitAppModule interface.
+type MockCommitAppModule struct {
+	ctrl     *gomock.Controller
+	recorder *MockCommitAppModuleMockRecorder
+}
+
+// MockCommitAppModuleMockRecorder is the mock recorder for MockCommitAppModule.
+type MockCommitAppModuleMockRecorder struct {
+	mock *MockCommitAppModule
+}
+
+// NewMockCommitAppModule creates a new mock instance.
+func NewMockCommitAppModule(ctrl *gomock.Controller) *MockCommitAppModule {
+	mock := &MockCommitAppModule{ctrl: ctrl}
+	mock.recorder = &MockCommitAppModuleMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockCommitAppModule) EXPECT() *MockCommitAppModuleMockRecorder {
+	return m.recorder
+}
+
+// Commit mocks base method.
+func (m *MockCommitAppModule) Commit(arg0 types1.Context) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Commit", arg0)
+}
+
+// Commit indicates an expected call of Commit.
+func (mr *MockCommitAppModuleMockRecorder) Commit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockCommitAppModule)(nil).Commit), arg0)
+}
+
+// GetQueryCmd mocks base method.
+func (m *MockCommitAppModule) GetQueryCmd() *cobra.Command {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueryCmd")
+	ret0, _ := ret[0].(*cobra.Command)
+	return ret0
+}
+
+// GetQueryCmd indicates an expected call of GetQueryCmd.
+func (mr *MockCommitAppModuleMockRecorder) GetQueryCmd() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueryCmd", reflect.TypeOf((*MockCommitAppModule)(nil).GetQueryCmd))
+}
+
+// GetTxCmd mocks base method.
+func (m *MockCommitAppModule) GetTxCmd() *cobra.Command {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTxCmd")
+	ret0, _ := ret[0].(*cobra.Command)
+	return ret0
+}
+
+// GetTxCmd indicates an expected call of GetTxCmd.
+func (mr *MockCommitAppModuleMockRecorder) GetTxCmd() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTxCmd", reflect.TypeOf((*MockCommitAppModule)(nil).GetTxCmd))
+}
+
+// Name mocks base method.
+func (m *MockCommitAppModule) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockCommitAppModuleMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockCommitAppModule)(nil).Name))
+}
+
+// RegisterGRPCGatewayRoutes mocks base method.
+func (m *MockCommitAppModule) RegisterGRPCGatewayRoutes(arg0 client.Context, arg1 *runtime.ServeMux) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterGRPCGatewayRoutes", arg0, arg1)
+}
+
+// RegisterGRPCGatewayRoutes indicates an expected call of RegisterGRPCGatewayRoutes.
+func (mr *MockCommitAppModuleMockRecorder) RegisterGRPCGatewayRoutes(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterGRPCGatewayRoutes", reflect.TypeOf((*MockCommitAppModule)(nil).RegisterGRPCGatewayRoutes), arg0, arg1)
+}
+
+// RegisterInterfaces mocks base method.
+func (m *MockCommitAppModule) RegisterInterfaces(arg0 types0.InterfaceRegistry) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterInterfaces", arg0)
+}
+
+// RegisterInterfaces indicates an expected call of RegisterInterfaces.
+func (mr *MockCommitAppModuleMockRecorder) RegisterInterfaces(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterInterfaces", reflect.TypeOf((*MockCommitAppModule)(nil).RegisterInterfaces), arg0)
+}
+
+// RegisterLegacyAminoCodec mocks base method.
+func (m *MockCommitAppModule) RegisterLegacyAminoCodec(arg0 *codec.LegacyAmino) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterLegacyAminoCodec", arg0)
+}
+
+// RegisterLegacyAminoCodec indicates an expected call of RegisterLegacyAminoCodec.
+func (mr *MockCommitAppModuleMockRecorder) RegisterLegacyAminoCodec(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterLegacyAminoCodec", reflect.TypeOf((*MockCommitAppModule)(nil).RegisterLegacyAminoCodec), arg0)
+}

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -45,7 +45,7 @@ func startInProcess(cfg Config, val *Validator) error {
 		tmCfg,
 		pvm.LoadOrGenFilePV(tmCfg.PrivValidatorKeyFile(), tmCfg.PrivValidatorStateFile()),
 		nodeKey,
-		proxy.NewLocalClientCreator(app),
+		proxy.NewUnsynchronizedLocalClientCreator(app),
 		genDocProvider,
 		node.DefaultDBProvider,
 		node.DefaultMetricsProvider(tmCfg.Instrumentation),

--- a/tools/cosmovisor/go.mod
+++ b/tools/cosmovisor/go.mod
@@ -143,3 +143,5 @@ require (
 	pgregory.net/rapid v0.5.5 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078

--- a/tools/cosmovisor/go.sum
+++ b/tools/cosmovisor/go.sum
@@ -266,8 +266,6 @@ github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/apd/v3 v3.1.0 h1:MK3Ow7LH0W8zkd5GMKA1PvS9qG3bWFI95WaVNfyZJ/w=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
-github.com/cometbft/cometbft v0.37.2 h1:XB0yyHGT0lwmJlFmM4+rsRnczPlHoAKFX6K8Zgc2/Jc=
-github.com/cometbft/cometbft v0.37.2/go.mod h1:Y2MMMN//O5K4YKd8ze4r9jmk4Y7h0ajqILXbH5JQFVs=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=
@@ -320,6 +318,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078 h1:gIBKK/wL+OTnMAEX8ZI3pxjGKq5nOHHoeGoMdk+3xR4=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/tools/rosetta/go.mod
+++ b/tools/rosetta/go.mod
@@ -117,3 +117,5 @@ require (
 	pgregory.net/rapid v0.5.5 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078

--- a/tools/rosetta/go.sum
+++ b/tools/rosetta/go.sum
@@ -102,8 +102,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cockroachdb/apd/v3 v3.1.0 h1:MK3Ow7LH0W8zkd5GMKA1PvS9qG3bWFI95WaVNfyZJ/w=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.37.2 h1:XB0yyHGT0lwmJlFmM4+rsRnczPlHoAKFX6K8Zgc2/Jc=
-github.com/cometbft/cometbft v0.37.2/go.mod h1:Y2MMMN//O5K4YKd8ze4r9jmk4Y7h0ajqILXbH5JQFVs=
 github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0ucsbo=
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=
@@ -156,6 +154,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.5.0 h1:3j8ya4Z4kMCwT5nXIKFSV84YS+HdqSSO0VsTQxaLAeM=
 github.com/dvsekhvalnov/jose2go v1.5.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078 h1:gIBKK/wL+OTnMAEX8ZI3pxjGKq5nOHHoeGoMdk+3xR4=
+github.com/dydxprotocol/cometbft v0.37.3-0.20230728195034-23effc208078/go.mod h1:cpghf0+1GJpJvrqpTHE6UyTcD05m/xllo0xpufL3PgA=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/types/abci.go
+++ b/types/abci.go
@@ -19,6 +19,10 @@ type BeginBlocker func(ctx Context, req abci.RequestBeginBlock) abci.ResponseBeg
 // e.g. BFT timestamps rather than block height for any periodic EndBlock logic
 type EndBlocker func(ctx Context, req abci.RequestEndBlock) abci.ResponseEndBlock
 
+// Commiter runs code during commit after the block number has been incremented and the `checkState` has been
+// branched for the new block.
+type Commiter func(ctx Context)
+
 // PeerFilter responds to p2p filtering queries from Tendermint
 type PeerFilter func(info string) abci.ResponseQuery
 

--- a/types/module/module_test.go
+++ b/types/module/module_test.go
@@ -101,6 +101,10 @@ func TestManagerOrderSetters(t *testing.T) {
 	require.Equal(t, []string{"module1", "module2"}, mm.OrderEndBlockers)
 	mm.SetOrderEndBlockers("module2", "module1")
 	require.Equal(t, []string{"module2", "module1"}, mm.OrderEndBlockers)
+
+	require.Equal(t, []string{"module1", "module2"}, mm.OrderCommiters)
+	mm.SetOrderCommiters("module2", "module1")
+	require.Equal(t, []string{"module2", "module1"}, mm.OrderCommiters)
 }
 
 func TestManager_RegisterInvariants(t *testing.T) {
@@ -250,4 +254,21 @@ func TestManager_EndBlock(t *testing.T) {
 	mockAppModule1.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	mockAppModule2.EXPECT().EndBlock(gomock.Any(), gomock.Eq(req)).Times(1).Return([]abci.ValidatorUpdate{{}})
 	require.Panics(t, func() { mm.EndBlock(sdk.Context{}, req) })
+}
+
+func TestManager_Commit(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	t.Cleanup(mockCtrl.Finish)
+
+	mockAppModule1 := mock.NewMockCommitAppModule(mockCtrl)
+	mockAppModule2 := mock.NewMockCommitAppModule(mockCtrl)
+	mockAppModule1.EXPECT().Name().Times(2).Return("module1")
+	mockAppModule2.EXPECT().Name().Times(2).Return("module2")
+	mm := module.NewManager(mockAppModule1, mockAppModule2)
+	require.NotNil(t, mm)
+	require.Equal(t, 2, len(mm.Modules))
+
+	mockAppModule1.EXPECT().Commit(gomock.Any()).Times(1)
+	mockAppModule2.EXPECT().Commit(gomock.Any()).Times(1)
+	mm.Commit(sdk.Context{})
 }

--- a/x/genutil/gentx.go
+++ b/x/genutil/gentx.go
@@ -84,7 +84,7 @@ func ValidateAccountInGenesis(
 	return nil
 }
 
-type deliverTxfn func(abci.RequestDeliverTx) abci.ResponseDeliverTx
+type deliverTxfn func(abci.RequestDeliverTx, bool) abci.ResponseDeliverTx
 
 // DeliverGenTxs iterates over all genesis txs, decodes each into a Tx and
 // invokes the provided deliverTxfn with the decoded Tx. It returns the result
@@ -105,7 +105,7 @@ func DeliverGenTxs(
 			return nil, fmt.Errorf("failed to encode GenTx '%s': %s", genTx, err)
 		}
 
-		res := deliverTx(abci.RequestDeliverTx{Tx: bz})
+		res := deliverTx(abci.RequestDeliverTx{Tx: bz}, false)
 		if !res.IsOK() {
 			return nil, fmt.Errorf("failed to execute DeliverTx for '%s': %s", genTx, res.Log)
 		}

--- a/x/genutil/gentx_test.go
+++ b/x/genutil/gentx_test.go
@@ -247,7 +247,7 @@ func (suite *GenTxTestSuite) TestDeliverGenTxs() {
 	testCases := []struct {
 		msg         string
 		malleate    func()
-		deliverTxFn func(abci.RequestDeliverTx) abci.ResponseDeliverTx
+		deliverTxFn func(abci.RequestDeliverTx, bool) abci.ResponseDeliverTx
 		expPass     bool
 	}{
 		{
@@ -261,7 +261,7 @@ func (suite *GenTxTestSuite) TestDeliverGenTxs() {
 				suite.Require().NoError(err)
 				genTxs[0] = tx
 			},
-			func(_ abci.RequestDeliverTx) abci.ResponseDeliverTx {
+			func(_ abci.RequestDeliverTx, _ bool) abci.ResponseDeliverTx {
 				return abci.ResponseDeliverTx{
 					Code:      sdkerrors.ErrNoSignatures.ABCICode(),
 					GasWanted: int64(10000000),
@@ -294,7 +294,7 @@ func (suite *GenTxTestSuite) TestDeliverGenTxs() {
 				suite.Require().NoError(err)
 				genTxs[0] = genTx
 			},
-			func(tx abci.RequestDeliverTx) abci.ResponseDeliverTx {
+			func(tx abci.RequestDeliverTx, _ bool) abci.ResponseDeliverTx {
 				return abci.ResponseDeliverTx{
 					Code:      sdkerrors.ErrUnauthorized.ABCICode(),
 					GasWanted: int64(10000000),

--- a/x/genutil/module.go
+++ b/x/genutil/module.go
@@ -137,7 +137,7 @@ type GenutilInputs struct {
 
 	AccountKeeper types.AccountKeeper
 	StakingKeeper types.StakingKeeper
-	DeliverTx     func(abci.RequestDeliverTx) abci.ResponseDeliverTx
+	DeliverTx     func(abci.RequestDeliverTx, bool) abci.ResponseDeliverTx
 	Config        client.TxConfig
 }
 

--- a/x/staking/client/cli/tx.go
+++ b/x/staking/client/cli/tx.go
@@ -25,8 +25,8 @@ import (
 var (
 	DefaultTokens                  = sdk.TokensFromConsensusPower(100, sdk.DefaultPowerReduction)
 	defaultAmount                  = DefaultTokens.String() + sdk.DefaultBondDenom
-	defaultCommissionRate          = "0.1"
-	defaultCommissionMaxRate       = "0.2"
+	defaultCommissionRate          = "1"
+	defaultCommissionMaxRate       = "1"
 	defaultCommissionMaxChangeRate = "0.01"
 	defaultMinSelfDelegation       = "1"
 )


### PR DESCRIPTION
I cleaned up the history of the dydx-fork-v0.47.3 by:
* merging the following changes together (7ac59ea607d3eec1cd2e97c0ca093a4fec3d752f 6e7a25b97ae954fd87f2ddf5431d6e0ccf8aafdf, 0bceac404bf1e3aa7a4013b81a152602856d7376) as they are all related to the committer change (implementation, tests and tests fix-up)
* removed the precommitter change (3005cd358c454ef479756b360d8d56e110d719a0) since it was reverted (0c99cbe07eddfc439c3482bfd2bebdebeab0e9cf)
* merging README.md only changes (4982c3bb654940040f4b26bfa56bab4d0f92eabe, c21e666ee7f79a9cc24991528382a7cc4167aa86, c5a5022880a62d84c7b7b0d04dac1b63f3c7ad22)
* dropped comment only changes that was for an [intercepts change](87292d90499e0b51daf76d4803d9c5fda14891fa) that is now the default behavior (1060d61c3f4b0789007998d6d7803bf2de340f14, fe02ee292d3a7e5f658dec0e8758b41678c33ef5)
* split out the CometBFT fork dependencies change into its own [commit](https://github.com/dydxprotocol/cosmos-sdk/pull/23/commits/1bb0a11fb805f889a660fa98b21be0c988ea3f28) out from the original change (a4e893fc4a45e732ec19b16316d4bf2b751f51f0)

There have been no changes to the `runTx` method since `0.47.1` so no changes were needed for `runCheckTxConcurrently`.
