### PR TITLE
[CLOB-930] Add ctx.Done() support to shutdown, make start-up wait time configurable, and add support for domain sockets for gRPC server and gRPC web server.

### DIFF
--- a/server/types/app.go
+++ b/server/types/app.go
@@ -3,6 +3,7 @@ package types
 import (
 	"encoding/json"
 	"io"
+	"sync/atomic"
 	"time"
 
 	dbm "github.com/cometbft/cometbft-db"
@@ -22,7 +23,11 @@ import (
 
 // ServerStartTime defines the time duration that the server need to stay running after startup
 // for the startup be considered successful
-const ServerStartTime = 5 * time.Second
+var ServerStartTime = atomic.Int64{}
+
+func init() {
+	ServerStartTime.Add(int64(5 * time.Second))
+}
 
 type (
 	// AppOptions defines an interface that is passed into an application

--- a/testutil/network/util.go
+++ b/testutil/network/util.go
@@ -89,14 +89,14 @@ func startInProcess(cfg Config, val *Validator) error {
 		select {
 		case err := <-errCh:
 			return err
-		case <-time.After(srvtypes.ServerStartTime): // assume server started successfully
+		case <-time.After(time.Duration(srvtypes.ServerStartTime.Load())): // assume server started successfully
 		}
 
 		val.api = apiSrv
 	}
 
 	if val.AppConfig.GRPC.Enable {
-		grpcSrv, err := servergrpc.StartGRPCServer(val.ClientCtx, app, val.AppConfig.GRPC)
+		grpcSrv, _, err := servergrpc.StartGRPCServer(val.ClientCtx, app, val.AppConfig.GRPC)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The purpose of these changes is to be able to launch the Cosmos app from the command entry point instead of directly via `dydx.NewApp` in the e2e test framework.

ctx.Done() support and was added in 0.50 with https://github.com/cosmos/cosmos-sdk/pull/15041

server start up time was removed in 0.50 with https://github.com/cosmos/cosmos-sdk/pull/15041

So a lot of this change will be removed with the Cosmos 0.50 upgrade.

<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
