### PR TITLE
[CLOB-1001] Add custom error value formatter to zerolog logging library

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -26,19 +26,11 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"cosmossdk.io/log"
-<<<<<<< HEAD
 	"cosmossdk.io/store"
 	"cosmossdk.io/store/snapshots"
 	snapshottypes "cosmossdk.io/store/snapshots/types"
 	storetypes "cosmossdk.io/store/types"
-=======
-	dbm "github.com/cometbft/cometbft-db"
-	tmcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
-	tmcfg "github.com/cometbft/cometbft/config"
-	tmlog "github.com/cometbft/cometbft/libs/log"
-	tmtypes "github.com/cometbft/cometbft/types"
 	errorspkg "github.com/pkg/errors"
->>>>>>> ecbbc8a84 (error key value formatter for zerolog for dd error tracking)
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client/flags"


### PR DESCRIPTION
For datadog error tracking, we want each error-based log field to have:
```
error: { stack: <stacktrace>, kind: <error_kind>, message: <error_message>} 
```

In order to do this, we introduce a custom error formatter to the zerolog logger that is used by `cometbft`, `cosmos-sdk`, and `v4-chain`. 

This formatter will run on any log event `Key:Value` tag value of type errors and massage it to be of the above form.
Thus, any error logs that have `"error": error` will be automatically datadog error tracked.

Note that `cosmos-sdk` emits error logs with the key `"err"` instead of `"error"`. Zerolog logging library is not powerful enough to support custom error event logging for stack traces in their custom `ErrorStackMarshallingFunc` [here](https://github.com/rs/zerolog/blob/master/fields.go#L78-L90). We could PR into the library, but an easier solution we have done is to set up a datadog log pipeline that remaps all `err` keys into `error` keys. That way, we can datadog error track `cosmos-sdk` errors.
 
 
 TL;DR all `error` and `err` keys are now properly datadog error tracked.