### PR TITLE
Fix grpc client dialing for tcp

### DIFF
--- a/server/start.go
+++ b/server/start.go
@@ -401,7 +401,16 @@ func startInProcess(parentCtx context.Context, ctx *Context, clientCtx client.Co
 				maxRecvMsgSize = serverconfig.DefaultGRPCMaxRecvMsgSize
 			}
 
-			grpcSrvAddrString := fmt.Sprintf("%s://%s", grpcSrvAddr.Network(), grpcSrvAddr.String())
+			var grpcSrvAddrString string
+			if grpcSrvAddr.Network() == "tcp" {
+				_, port, err := net.SplitHostPort(grpcSrvAddr.String())
+				if err != nil {
+					return err
+				}
+				grpcSrvAddrString = fmt.Sprintf("127.0.0.1:%s", port)
+			} else {
+				grpcSrvAddrString = fmt.Sprintf("%s://%s", grpcSrvAddr.Network(), grpcSrvAddr.String())
+			}
 			// If grpc is enabled, configure grpc client for grpc gateway.
 			grpcClient, err := grpc.Dial(
 				grpcSrvAddrString,

--- a/server/start.go
+++ b/server/start.go
@@ -403,12 +403,14 @@ func startInProcess(parentCtx context.Context, ctx *Context, clientCtx client.Co
 
 			var grpcSrvAddrString string
 			if grpcSrvAddr.Network() == "tcp" {
+				// Use original cosmos behavior for tcp.
 				_, port, err := net.SplitHostPort(grpcSrvAddr.String())
 				if err != nil {
 					return err
 				}
 				grpcSrvAddrString = fmt.Sprintf("127.0.0.1:%s", port)
 			} else {
+				// This can support UDS at the very least. See https://github.com/grpc/grpc/blob/master/doc/naming.md for details.
 				grpcSrvAddrString = fmt.Sprintf("%s://%s", grpcSrvAddr.Network(), grpcSrvAddr.String())
 			}
 			// If grpc is enabled, configure grpc client for grpc gateway.


### PR DESCRIPTION
bdf96fd broke the default tcp dialing. `Dial` doesn't accept `tcp://` and also we should be dialing `127.0.0.1` instead of `[::]`. This fixes tcp behavior to be backwards compatible while not breaking the uds behavior.