### PR TITLE
[CORE-850] Update default values for new Gov parameters

### DIFF
--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -35,6 +35,7 @@ func MigrateStore(ctx sdk.Context, storeService corestoretypes.KVStoreService, c
 		return err
 	}
 
+	// defaultParams is updated with default values for new parameters introduced in v0.50.
 	defaultParams := govv1.DefaultParams()
 	params.ExpeditedMinDeposit = params.MinDeposit // Use regular `min_deposit` as `expedited_min_deposit`
 	params.ExpeditedVotingPeriod = defaultParams.ExpeditedVotingPeriod

--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -36,7 +36,7 @@ func MigrateStore(ctx sdk.Context, storeService corestoretypes.KVStoreService, c
 	}
 
 	defaultParams := govv1.DefaultParams()
-	params.ExpeditedMinDeposit = defaultParams.ExpeditedMinDeposit
+	params.ExpeditedMinDeposit = params.MinDeposit // Use regular `min_deposit` as `expedited_min_deposit`
 	params.ExpeditedVotingPeriod = defaultParams.ExpeditedVotingPeriod
 	params.ExpeditedThreshold = defaultParams.ExpeditedThreshold
 	params.ProposalCancelRatio = defaultParams.ProposalCancelRatio

--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -37,7 +37,9 @@ func MigrateStore(ctx sdk.Context, storeService corestoretypes.KVStoreService, c
 
 	// defaultParams is updated with default values for new parameters introduced in v0.50.
 	defaultParams := govv1.DefaultParams()
-	params.ExpeditedMinDeposit = params.MinDeposit // Use regular `min_deposit` as `expedited_min_deposit`
+	// Use `MinDeposit` from state as `ExpeditedMinDeposit`.
+	params.ExpeditedMinDeposit = params.MinDeposit
+	// For below five parameters, use the updated default values.
 	params.ExpeditedVotingPeriod = defaultParams.ExpeditedVotingPeriod
 	params.ExpeditedThreshold = defaultParams.ExpeditedThreshold
 	params.ProposalCancelRatio = defaultParams.ProposalCancelRatio

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -43,7 +43,7 @@ func TestMigrateStore(t *testing.T) {
 	bz = store.Get(v4.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &params))
 	require.NotNil(t, params)
-	// Expect ExpeditedMinDeposit to equal previous MinDeposit after migraiton.
+	// After migration, expect `ExpeditedMinDeposit` to equal previous value of `MinDeposit`.
 	require.Equal(t, params.MinDeposit, params.ExpeditedMinDeposit)
 	require.Equal(t, v1.DefaultParams().ExpeditedThreshold, params.ExpeditedThreshold)
 	require.Equal(t, v1.DefaultParams().ExpeditedVotingPeriod, params.ExpeditedVotingPeriod)

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -45,9 +45,11 @@ func TestMigrateStore(t *testing.T) {
 	require.NotNil(t, params)
 	// After migration, expect `ExpeditedMinDeposit` to equal previous value of `MinDeposit`.
 	require.Equal(t, params.MinDeposit, params.ExpeditedMinDeposit)
-	require.Equal(t, v1.DefaultParams().ExpeditedThreshold, params.ExpeditedThreshold)
-	require.Equal(t, v1.DefaultParams().ExpeditedVotingPeriod, params.ExpeditedVotingPeriod)
-	require.Equal(t, v1.DefaultParams().MinDepositRatio, params.MinDepositRatio)
+	require.Equal(t, "0.750000000000000000", params.ExpeditedThreshold)
+	require.Equal(t, "1.000000000000000000", params.ProposalCancelRatio)
+	require.Equal(t, "", params.ProposalCancelDest)
+	require.Equal(t, 24*time.Hour, *params.ExpeditedVotingPeriod)
+	require.Equal(t, "0.010000000000000000", params.MinDepositRatio)
 
 	// Check constitution
 	result, err := constitutionCollection.Get(ctx)

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -43,7 +43,8 @@ func TestMigrateStore(t *testing.T) {
 	bz = store.Get(v4.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &params))
 	require.NotNil(t, params)
-	require.Equal(t, v1.DefaultParams().ExpeditedMinDeposit, params.ExpeditedMinDeposit)
+	// Expect ExpeditedMinDeposit to equal previous MinDeposit after migraiton.
+	require.Equal(t, params.MinDeposit, params.ExpeditedMinDeposit)
 	require.Equal(t, v1.DefaultParams().ExpeditedThreshold, params.ExpeditedThreshold)
 	require.Equal(t, v1.DefaultParams().ExpeditedVotingPeriod, params.ExpeditedVotingPeriod)
 	require.Equal(t, v1.DefaultParams().MinDepositRatio, params.MinDepositRatio)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -29,9 +29,9 @@ var (
 	DefaultVetoThreshold          = sdkmath.LegacyNewDecWithPrec(334, 3)
 	DefaultMinInitialDepositRatio = sdkmath.LegacyZeroDec()
 	// (New default value for v0.50 migration) 100% of deposit will not be returned to the depositors,
-	// if the proposal is cancelled. Also, `MsgCancelProposal` is disabled in application.
+	// if the proposal is canceled. Also, `MsgCancelProposal` is disabled in application.
 	DefaultProposalCancelRatio = sdkmath.LegacyMustNewDecFromStr("1.0")
-	// (New default value for v0.50 migration) 100% of deposit is burned if the proposal is cancelled.
+	// (New default value for v0.50 migration) 100% of deposit is burned if the proposal is canceled.
 	// Also, `MsgCancelProposal` is disabled in application.
 	DefaultProposalCancelDestAddress = ""
 	DefaultBurnProposalPrevote       = false // set to false to replicate behavior of when this change was made (0.47)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -37,7 +37,8 @@ var (
 	DefaultBurnProposalPrevote       = false // set to false to replicate behavior of when this change was made (0.47)
 	DefaultBurnVoteQuorom            = false // set to false to  replicate behavior of when this change was made (0.47)
 	DefaultBurnVoteVeto              = true  // set to true to replicate behavior of when this change was made (0.47)
-	DefaultMinDepositRatio           = sdkmath.LegacyMustNewDecFromStr("0.01")
+	// (New default value for v0.50 migration) 1% of `min_deposit` is required to make a deposit.
+	DefaultMinDepositRatio = sdkmath.LegacyMustNewDecFromStr("0.01")
 )
 
 // Deprecated: NewDepositParams creates a new DepositParams object

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -11,21 +11,28 @@ import (
 
 // Default period for deposits & voting
 const (
-	DefaultPeriod                         time.Duration = time.Hour * 24 * 2 // 2 days
+	DefaultPeriod time.Duration = time.Hour * 24 * 2 // 2 days
+	// (New default value for v0.50 migration) 24 hours voting period for expedited proposals.
 	DefaultExpeditedPeriod                time.Duration = time.Hour * 24 * 1 // 1 day
 	DefaultMinExpeditedDepositTokensRatio               = 5
 )
 
 // Default governance params
 var (
-	DefaultMinDepositTokens          = sdkmath.NewInt(10000000)
+	DefaultMinDepositTokens = sdkmath.NewInt(10000000)
+	// During v0.50 migration, this default value is overwritten with existing value of `MinDeposit`.
 	DefaultMinExpeditedDepositTokens = DefaultMinDepositTokens.Mul(sdkmath.NewInt(DefaultMinExpeditedDepositTokensRatio))
 	DefaultQuorum                    = sdkmath.LegacyNewDecWithPrec(334, 3)
 	DefaultThreshold                 = sdkmath.LegacyNewDecWithPrec(5, 1)
-	DefaultExpeditedThreshold        = sdkmath.LegacyNewDecWithPrec(667, 3)
-	DefaultVetoThreshold             = sdkmath.LegacyNewDecWithPrec(334, 3)
-	DefaultMinInitialDepositRatio    = sdkmath.LegacyZeroDec()
-	DefaultProposalCancelRatio       = sdkmath.LegacyMustNewDecFromStr("0.5")
+	// (New default value for v0.50 migration) 75% of Yes votes required for an expedited proposal to pass.
+	DefaultExpeditedThreshold     = sdkmath.LegacyNewDecWithPrec(75, 2)
+	DefaultVetoThreshold          = sdkmath.LegacyNewDecWithPrec(334, 3)
+	DefaultMinInitialDepositRatio = sdkmath.LegacyZeroDec()
+	// (New default value for v0.50 migration) 100% of deposit will not be returned to the depositors,
+	// if the proposal is cancelled. Also, `MsgCancelProposal` is disabled in application.
+	DefaultProposalCancelRatio = sdkmath.LegacyMustNewDecFromStr("1.0")
+	// (New default value for v0.50 migration) 100% of deposit is burned if the proposal is cancelled.
+	// Also, `MsgCancelProposal` is disabled in application.
 	DefaultProposalCancelDestAddress = ""
 	DefaultBurnProposalPrevote       = false // set to false to replicate behavior of when this change was made (0.47)
 	DefaultBurnVoteQuorom            = false // set to false to  replicate behavior of when this change was made (0.47)


### PR DESCRIPTION
## Description

Update default values for new gov parameters in v0.50 migration. See values and rationale [here](https://www.notion.so/dydx/AC-Priv-Genesis-Parameters-d2321636dd494ee49cc95b7825cbbc98?pvs=4#2490f3813f944d3e9baac8633e240e8a).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
