### PR TITLE
Re-apply default gov parameters update onto 0.50.3

### DIFF
--- a/x/gov/migrations/v5/store.go
+++ b/x/gov/migrations/v5/store.go
@@ -35,8 +35,11 @@ func MigrateStore(ctx sdk.Context, storeService corestoretypes.KVStoreService, c
 		return err
 	}
 
+	// defaultParams is updated with default values for new parameters introduced in v0.50.
 	defaultParams := govv1.DefaultParams()
-	params.ExpeditedMinDeposit = defaultParams.ExpeditedMinDeposit
+	// Use `MinDeposit` from state as `ExpeditedMinDeposit`.
+	params.ExpeditedMinDeposit = params.MinDeposit
+	// For below five parameters, use the updated default values.
 	params.ExpeditedVotingPeriod = defaultParams.ExpeditedVotingPeriod
 	params.ExpeditedThreshold = defaultParams.ExpeditedThreshold
 	params.ProposalCancelRatio = defaultParams.ProposalCancelRatio

--- a/x/gov/migrations/v5/store_test.go
+++ b/x/gov/migrations/v5/store_test.go
@@ -43,10 +43,13 @@ func TestMigrateStore(t *testing.T) {
 	bz = store.Get(v4.ParamsKey)
 	require.NoError(t, cdc.Unmarshal(bz, &params))
 	require.NotNil(t, params)
-	require.Equal(t, v1.DefaultParams().ExpeditedMinDeposit, params.ExpeditedMinDeposit)
-	require.Equal(t, v1.DefaultParams().ExpeditedThreshold, params.ExpeditedThreshold)
-	require.Equal(t, v1.DefaultParams().ExpeditedVotingPeriod, params.ExpeditedVotingPeriod)
-	require.Equal(t, v1.DefaultParams().MinDepositRatio, params.MinDepositRatio)
+	// After migration, expect `ExpeditedMinDeposit` to equal previous value of `MinDeposit`.
+	require.Equal(t, params.MinDeposit, params.ExpeditedMinDeposit)
+	require.Equal(t, "0.750000000000000000", params.ExpeditedThreshold)
+	require.Equal(t, "1.000000000000000000", params.ProposalCancelRatio)
+	require.Equal(t, "", params.ProposalCancelDest)
+	require.Equal(t, 24*time.Hour, *params.ExpeditedVotingPeriod)
+	require.Equal(t, "0.010000000000000000", params.MinDepositRatio)
 
 	// Check constitution
 	result, err := constitutionCollection.Get(ctx)

--- a/x/gov/types/v1/params.go
+++ b/x/gov/types/v1/params.go
@@ -11,26 +11,34 @@ import (
 
 // Default period for deposits & voting
 const (
-	DefaultPeriod                         time.Duration = time.Hour * 24 * 2 // 2 days
+	DefaultPeriod time.Duration = time.Hour * 24 * 2 // 2 days
+	// (New default value for v0.50 migration) 24 hours voting period for expedited proposals.
 	DefaultExpeditedPeriod                time.Duration = time.Hour * 24 * 1 // 1 day
 	DefaultMinExpeditedDepositTokensRatio               = 5
 )
 
 // Default governance params
 var (
-	DefaultMinDepositTokens          = sdkmath.NewInt(10000000)
+	DefaultMinDepositTokens = sdkmath.NewInt(10000000)
+	// During v0.50 migration, this default value is overwritten with existing value of `MinDeposit`.
 	DefaultMinExpeditedDepositTokens = DefaultMinDepositTokens.Mul(sdkmath.NewInt(DefaultMinExpeditedDepositTokensRatio))
 	DefaultQuorum                    = sdkmath.LegacyNewDecWithPrec(334, 3)
 	DefaultThreshold                 = sdkmath.LegacyNewDecWithPrec(5, 1)
-	DefaultExpeditedThreshold        = sdkmath.LegacyNewDecWithPrec(667, 3)
-	DefaultVetoThreshold             = sdkmath.LegacyNewDecWithPrec(334, 3)
-	DefaultMinInitialDepositRatio    = sdkmath.LegacyZeroDec()
-	DefaultProposalCancelRatio       = sdkmath.LegacyMustNewDecFromStr("0.5")
+	// (New default value for v0.50 migration) 75% of Yes votes required for an expedited proposal to pass.
+	DefaultExpeditedThreshold     = sdkmath.LegacyNewDecWithPrec(75, 2)
+	DefaultVetoThreshold          = sdkmath.LegacyNewDecWithPrec(334, 3)
+	DefaultMinInitialDepositRatio = sdkmath.LegacyZeroDec()
+	// (New default value for v0.50 migration) 100% of deposit will not be returned to the depositors,
+	// if the proposal is canceled. Also, `MsgCancelProposal` is disabled in application.
+	DefaultProposalCancelRatio = sdkmath.LegacyMustNewDecFromStr("1.0")
+	// (New default value for v0.50 migration) 100% of deposit is burned if the proposal is canceled.
+	// Also, `MsgCancelProposal` is disabled in application.
 	DefaultProposalCancelDestAddress = ""
 	DefaultBurnProposalPrevote       = false // set to false to replicate behavior of when this change was made (0.47)
 	DefaultBurnVoteQuorom            = false // set to false to  replicate behavior of when this change was made (0.47)
 	DefaultBurnVoteVeto              = true  // set to true to replicate behavior of when this change was made (0.47)
-	DefaultMinDepositRatio           = sdkmath.LegacyMustNewDecFromStr("0.01")
+	// (New default value for v0.50 migration) 1% of `min_deposit` is required to make a deposit.
+	DefaultMinDepositRatio = sdkmath.LegacyMustNewDecFromStr("0.01")
 )
 
 // Deprecated: NewDepositParams creates a new DepositParams object


### PR DESCRIPTION
From https://github.com/dydxprotocol/cosmos-sdk/pull/34, which was merged onto 0.50.1