### PR TITLE
[STAB-31] Allow AnteHandler to control locking semantics.

### DIFF
--- a/baseapp/baseapp.go
+++ b/baseapp/baseapp.go
@@ -189,7 +189,7 @@ type BaseApp struct {
 	optimisticExec *oe.OptimisticExecution
 
 	// Used to synchronize the application when using an unsynchronized ABCI++ client.
-	mtx sync.Mutex
+	mtx sync.RWMutex
 }
 
 // NewBaseApp returns a reference to an initialized BaseApp. It accepts a
@@ -653,6 +653,11 @@ func (app *BaseApp) getContextForTx(mode execMode, txBytes []byte) sdk.Context {
 		WithTxBytes(txBytes)
 	// WithVoteInfos(app.voteInfos) // TODO: identify if this is needed
 
+	// Use a new gas meter since loading the consensus params below consumes gas and causes a race condition.
+	//
+	// TODO(STAB-35): See if this can be removed.
+	ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+
 	ctx = ctx.WithConsensusParams(app.GetConsensusParams(ctx))
 
 	if mode == execModeReCheck {
@@ -668,7 +673,7 @@ func (app *BaseApp) getContextForTx(mode execMode, txBytes []byte) sdk.Context {
 
 // cacheTxContext returns a new context based off of the provided context with
 // a branched multi-store.
-func (app *BaseApp) cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context, storetypes.CacheMultiStore) {
+func cacheTxContext(ctx sdk.Context, txBytes []byte) (sdk.Context, storetypes.CacheMultiStore) {
 	ms := ctx.MultiStore()
 	// TODO: https://github.com/cosmos/cosmos-sdk/issues/2824
 	msCache := ms.CacheMultiStore()
@@ -842,8 +847,8 @@ func (app *BaseApp) runCheckTxConcurrently(mode execMode, txBytes []byte) (gInfo
 	// embedded here to ensure that the lifetime of the mutex is limited to only this function allowing
 	// for the return values to be computed without holding the lock.
 	func() {
-		app.mtx.Lock()
-		defer app.mtx.Unlock()
+		app.mtx.RLock()
+		defer app.mtx.RUnlock()
 
 		ctx := app.getContextForTx(mode, txBytes)
 		ms := ctx.MultiStore()
@@ -859,25 +864,17 @@ func (app *BaseApp) runCheckTxConcurrently(mode execMode, txBytes []byte) (gInfo
 		}()
 
 		if app.anteHandler != nil {
-			var (
-				anteCtx sdk.Context
-				msCache storetypes.CacheMultiStore
-				newCtx  sdk.Context
-			)
+			var newCtx sdk.Context
 
-			// Branch context before AnteHandler call in case it aborts.
-			// This is required for both CheckTx and DeliverTx.
-			// Ref: https://github.com/cosmos/cosmos-sdk/issues/2772
-			//
-			// NOTE: Alternatively, we could require that AnteHandler ensures that
-			// writes do not happen if aborted/failed.  This may have some
-			// performance benefits, but it'll be more difficult to get right.
-			anteCtx, msCache = app.cacheTxContext(ctx, txBytes)
-			anteCtx = anteCtx.WithEventManager(sdk.NewEventManager())
-			newCtx, err = app.anteHandler(anteCtx, tx, mode == execModeSimulate)
+			// Typically the Cosmos SDK branches the context before passing it to the ante handler but here we
+			// allow the application's AnteHandler to control branching semantics for the context itself.
+			// We also guarantee that the passed in context is held with a read lock allowing for concurrent
+			// execution.
+			anteCtx := ctx.WithEventManager(sdk.NewEventManager())
+			newCtx, err = app.anteHandler(anteCtx, tx, false /* mode == execModeSimulate */)
 
 			if !newCtx.IsZero() {
-				// At this point, newCtx.MultiStore() is a store branch, or something else
+				// At this point, ctx.MultiStore() is a store branch, or something else
 				// replaced by the AnteHandler. We want the original multistore.
 				//
 				// Also, in the case of the tx aborting, we need to track gas consumed via
@@ -899,7 +896,6 @@ func (app *BaseApp) runCheckTxConcurrently(mode execMode, txBytes []byte) (gInfo
 				return
 			}
 
-			msCache.Write()
 			anteEvents = events.ToABCIEvents()
 		}
 
@@ -1022,7 +1018,7 @@ func (app *BaseApp) runTx(mode execMode, txBytes []byte) (gInfo sdk.GasInfo, res
 		// NOTE: Alternatively, we could require that AnteHandler ensures that
 		// writes do not happen if aborted/failed.  This may have some
 		// performance benefits, but it'll be more difficult to get right.
-		anteCtx, msCache = app.cacheTxContext(ctx, txBytes)
+		anteCtx, msCache = cacheTxContext(ctx, txBytes)
 		anteCtx = anteCtx.WithEventManager(sdk.NewEventManager())
 		newCtx, err := app.anteHandler(anteCtx, tx, mode == execModeSimulate)
 
@@ -1065,7 +1061,7 @@ func (app *BaseApp) runTx(mode execMode, txBytes []byte) (gInfo sdk.GasInfo, res
 	// Create a new Context based off of the existing Context with a MultiStore branch
 	// in case message processing fails. At this point, the MultiStore
 	// is a branch of a branch.
-	runMsgCtx, msCache := app.cacheTxContext(ctx, txBytes)
+	runMsgCtx, msCache := cacheTxContext(ctx, txBytes)
 
 	// Attempt to execute all messages and only update state if all messages pass
 	// and we're in DeliverTx. Note, runMsgs will never return a reference to a

--- a/baseapp/locking.go
+++ b/baseapp/locking.go
@@ -1,0 +1,34 @@
+package baseapp
+
+import (
+	"sync"
+
+	storetypes "cosmossdk.io/store/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+var _ sdk.AnteDecorator = lockAndCacheContextDecorator{}
+
+func NewLockAndCacheContextAnteDecorator() sdk.AnteDecorator {
+	return lockAndCacheContextDecorator{
+		mtx: &sync.Mutex{},
+	}
+}
+
+type lockAndCacheContextDecorator struct {
+	mtx *sync.Mutex
+}
+
+func (l lockAndCacheContextDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+
+	var cacheMs storetypes.CacheMultiStore
+	ctx, cacheMs = cacheTxContext(ctx, ctx.TxBytes())
+	newCtx, err := next(ctx, tx, simulate)
+	if err == nil {
+		cacheMs.Write()
+	}
+	return newCtx, err
+}

--- a/baseapp/locking_test.go
+++ b/baseapp/locking_test.go
@@ -1,0 +1,133 @@
+package baseapp_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+	"testing"
+
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	storemetrics "cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+func TestLockAndCacheContextDecorator(t *testing.T) {
+	tests := map[string]struct {
+		err error
+	}{
+		"AnteHandle succeeds": {},
+		"AnteHandle returns error": {
+			err: fmt.Errorf("Fake test failure"),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			key := []byte("key")
+			db := dbm.NewMemDB()
+
+			storeKey := storetypes.NewKVStoreKey("test")
+			cms := store.NewCommitMultiStore(db, log.NewNopLogger(), storemetrics.NewNoOpMetrics())
+			cms.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+			ctx := sdk.NewContext(cms, cmtproto.Header{}, true, log.NewNopLogger())
+			cms.LoadLatestVersion()
+
+			cms.GetKVStore(storeKey).Set(key, encode(0))
+			ctx.WithTxBytes([]byte("fake tx bytes"))
+
+			l := baseapp.NewLockAndCacheContextAnteDecorator()
+
+			_, err := l.AnteHandle(
+				ctx,
+				nil,
+				false,
+				func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+					store := ctx.MultiStore().GetKVStore(storeKey)
+					store.Set(key, encode(decode(store.Get(key))+1))
+					return ctx, tc.err
+				},
+			)
+
+			actual := int(decode(cms.GetKVStore(storeKey).Get(key)))
+
+			require.Equal(t, tc.err, err)
+			if tc.err != nil {
+				require.Equal(t, 0, actual)
+			} else {
+				require.Equal(t, 1, actual)
+			}
+		})
+	}
+}
+
+func TestLockAndCacheContextDecorator_Concurrency(t *testing.T) {
+	const numThreads = 999
+	key := []byte("key")
+	db := dbm.NewMemDB()
+
+	errResp := fmt.Errorf("Fake test failure")
+
+	storeKey := storetypes.NewKVStoreKey("test")
+	cms := store.NewCommitMultiStore(db, log.NewNopLogger(), storemetrics.NewNoOpMetrics())
+	cms.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+	ctx := sdk.NewContext(cms, cmtproto.Header{}, true, log.NewNopLogger())
+	cms.LoadLatestVersion()
+
+	cms.GetKVStore(storeKey).Set(key, encode(0))
+	ctx.WithTxBytes([]byte("fake tx bytes"))
+
+	l := baseapp.NewLockAndCacheContextAnteDecorator()
+
+	wg := sync.WaitGroup{}
+	wg.Add(numThreads)
+	for i := 0; i < numThreads; i++ {
+		ii := i
+		go func() {
+			_, err := l.AnteHandle(
+				ctx,
+				nil,
+				false,
+				func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+					store := ctx.MultiStore().GetKVStore(storeKey)
+					store.Set(key, encode(decode(store.Get(key))+1))
+					if ii%3 == 0 {
+						return ctx, nil
+					}
+					return ctx, errResp
+				},
+			)
+			wg.Done()
+
+			if ii%3 == 0 {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// We run 1/3 the goroutines with failures and 2/3 with successes. Since each run is expected to execute
+	// independently of each other after the locking decorator we know that exactly 2/3's must succeed.
+
+	actual := int(decode(cms.GetKVStore(storeKey).Get(key)))
+	require.Equal(t, numThreads/3, actual)
+}
+
+func encode(v uint32) []byte {
+	rval := make([]byte, 4)
+	binary.LittleEndian.PutUint32(rval, v)
+	return rval
+}
+
+func decode(v []byte) uint32 {
+	return binary.LittleEndian.Uint32(v)
+}

--- a/baseapp/utils_test.go
+++ b/baseapp/utils_test.go
@@ -210,7 +210,7 @@ func counterEvent(evType string, msgCount int64) sdk.Events {
 }
 
 func anteHandlerTxTest(t *testing.T, capKey storetypes.StoreKey, storeKey []byte) sdk.AnteHandler {
-	return func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+	return wrapWithLockAndCacheContextDecorator(func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
 		store := ctx.KVStore(capKey)
 		counter, failOnAnte := parseTxMemo(t, tx)
 
@@ -229,7 +229,7 @@ func anteHandlerTxTest(t *testing.T, capKey storetypes.StoreKey, storeKey []byte
 
 		ctx = ctx.WithPriority(testTxPriority)
 		return ctx, nil
-	}
+	})
 }
 
 func incrementingCounter(t *testing.T, store storetypes.KVStore, counterKey []byte, counter int64) (*sdk.Result, error) {

--- a/simapp/ante.go
+++ b/simapp/ante.go
@@ -5,6 +5,7 @@ import (
 
 	circuitante "cosmossdk.io/x/circuit/ante"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 )
@@ -32,6 +33,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
+		baseapp.NewLockAndCacheContextAnteDecorator(),
 		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		circuitante.NewCircuitBreakerDecorator(options.CircuitKeeper),
 		ante.NewExtensionOptionsDecorator(options.ExtensionOptionChecker),

--- a/x/auth/ante/ante.go
+++ b/x/auth/ante/ante.go
@@ -5,6 +5,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	txsigning "cosmossdk.io/x/tx/signing"
 
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -39,6 +40,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 	}
 
 	anteDecorators := []sdk.AnteDecorator{
+		baseapp.NewLockAndCacheContextAnteDecorator(),
 		NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
 		NewExtensionOptionsDecorator(options.ExtensionOptionChecker),
 		NewValidateBasicDecorator(),


### PR DESCRIPTION
<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

[STAB-31] Allow AnteHandler to control locking semantics.

Updated existing usages of AnteHandler in cosmos to use the instance which always locks restoring the existing contract.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
