### PR TITLE
Fix typos

### DIFF
--- a/baseapp/abci.go
+++ b/baseapp/abci.go
@@ -936,7 +936,7 @@ func (app *BaseApp) FinalizeBlock(req *abci.RequestFinalizeBlock) (res *abci.Res
 	return res, err
 }
 
-// checkHalt checkes if height or time exceeds halt-height or halt-time respectively.
+// checkHalt checks if height or time exceeds halt-height or halt-time respectively.
 func (app *BaseApp) checkHalt(height int64, time time.Time) error {
 	var halt bool
 	switch {

--- a/collections/colltest/codec.go
+++ b/collections/colltest/codec.go
@@ -119,7 +119,7 @@ func (m mockValueCodec[T]) Decode(b []byte) (t T, err error) {
 
 	typ, exists := m.seenTypes[wrappedValue.TypeName]
 	if !exists {
-		return t, fmt.Errorf("uknown type %s, you're dealing with interfaces... in order to make the interface types known for the MockValueCodec, you need to first encode them", wrappedValue.TypeName)
+		return t, fmt.Errorf("unknown type %s, you're dealing with interfaces... in order to make the interface types known for the MockValueCodec, you need to first encode them", wrappedValue.TypeName)
 	}
 
 	newT := reflect.New(typ).Interface()

--- a/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
+++ b/crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h
@@ -357,7 +357,7 @@ SECP256K1_API int secp256k1_ecdsa_signature_serialize_compact(
 /** Verify an ECDSA signature.
  *
  *  Returns: 1: correct signature
- *           0: incorrect or unparseable signature
+ *           0: incorrect or unparsable signature
  *  Args:    ctx:       a secp256k1 context object, initialized for verification.
  *  In:      sig:       the signature being verified (cannot be NULL)
  *           msg32:     the 32-byte message hash being verified (cannot be NULL)


### PR DESCRIPTION
# Fix Typos in Multiple Files

## Summary
This pull request fixes several typos across the codebase to improve code readability and maintain high documentation standards.

## Changes
### Files Modified
1. **`baseapp/abci.go`**
   - Fixed typo: `checkes` → `checks`.

2. **`collections/colltest/codec.go`**
   - Fixed typo: `uknown` → `unknown`.

3. **`crypto/keys/secp256k1/internal/secp256k1/libsecp256k1/include/secp256k1.h`**
   - Fixed typo: `unparseable` → `unparsable`.

## Why This Change Was Made
- Typos can lead to confusion in understanding the code and decrease the professional quality of the project. Fixing these issues ensures clarity and adherence to coding standards.

## Checklist
- [x] Reviewed and corrected typos.
- [x] Verified the changes do not affect functionality.
- [x] Confirmed adherence to the contributing guidelines and project standards.

---

If there are any additional typos or corrections that need to be addressed, please let me know. Thank you!
