### PR TITLE
Increase number of max calls to 10,000.

### DIFF
--- a/codec/types/interface_registry.go
+++ b/codec/types/interface_registry.go
@@ -17,7 +17,7 @@ var (
 
 	// MaxUnpackAnySubCalls extension point that defines the maximum number of sub-calls allowed during the unpacking
 	// process of protobuf Any messages.
-	MaxUnpackAnySubCalls = 100
+	MaxUnpackAnySubCalls = 10000
 
 	// MaxUnpackAnyRecursionDepth extension point that defines the maximum allowed recursion depth during protobuf Any
 	// message unpacking.


### PR DESCRIPTION
Increase number of max calls for the ASA-0012 patch to 10,000 to account for large gov proposals that exist in dYdX chain.

Context: https://dydx-team.slack.com/archives/C062RQGR2RK/p1734650527334499
