### PR TITLE
update cometbft version where CanPropose is replaced by ProposeDisabled in validator abci updates

### DIFF
--- a/api/cosmos/staking/v1beta1/query.pulsar.go
+++ b/api/cosmos/staking/v1beta1/query.pulsar.go
@@ -15766,7 +15766,7 @@ type QueryProposersResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// proposers contains the list of validator operator addresses eligible to propose blocks.
+	// proposers is the list of operator addresses of validators eligible to propose blocks.
 	Proposers []string `protobuf:"bytes,1,rep,name=proposers,proto3" json:"proposers,omitempty"`
 }
 

--- a/api/cosmos/staking/v1beta1/query_grpc.pb.go
+++ b/api/cosmos/staking/v1beta1/query_grpc.pb.go
@@ -93,7 +93,7 @@ type QueryClient interface {
 	Pool(ctx context.Context, in *QueryPoolRequest, opts ...grpc.CallOption) (*QueryPoolResponse, error)
 	// Parameters queries the staking parameters.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
-	// Proposers queries the current set of validators eligible to propose blocks.
+	// Proposers queries the set of validators eligible to propose blocks.
 	Proposers(ctx context.Context, in *QueryProposersRequest, opts ...grpc.CallOption) (*QueryProposersResponse, error)
 }
 
@@ -297,7 +297,7 @@ type QueryServer interface {
 	Pool(context.Context, *QueryPoolRequest) (*QueryPoolResponse, error)
 	// Parameters queries the staking parameters.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
-	// Proposers queries the current set of validators eligible to propose blocks.
+	// Proposers queries the set of validators eligible to propose blocks.
 	Proposers(context.Context, *QueryProposersRequest) (*QueryProposersResponse, error)
 	mustEmbedUnimplementedQueryServer()
 }

--- a/baseapp/utils_test.go
+++ b/baseapp/utils_test.go
@@ -65,7 +65,7 @@ func GenesisStateWithSingleValidator(t *testing.T, codec codec.Codec, builder *r
 	require.NoError(t, err)
 
 	// create validator set with single validator
-	validator := cmttypes.NewValidator(pubKey, 1, true)
+	validator := cmttypes.NewValidator(pubKey, 1, false)
 	valSet := cmttypes.NewValidatorSet([]*cmttypes.Validator{validator})
 
 	// generate genesis account

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -21245,9 +21245,7 @@ paths:
         - Query
   /cosmos/staking/v1beta1/proposers:
     get:
-      summary: >-
-        Proposers queries the current set of validators eligible to propose
-        blocks.
+      summary: Proposers queries the set of validators eligible to propose blocks.
       operationId: Proposers
       responses:
         '200':
@@ -21260,7 +21258,7 @@ paths:
                 items:
                   type: string
                 description: >-
-                  proposers contains the list of validator operator addresses
+                  proposers is the list of operator addresses of validators
                   eligible to propose blocks.
             description: >-
               QueryProposersResponse is response type for the Query/Proposers
@@ -53814,8 +53812,8 @@ definitions:
         items:
           type: string
         description: >-
-          proposers contains the list of validator operator addresses eligible
-          to propose blocks.
+          proposers is the list of operator addresses of validators eligible to
+          propose blocks.
     description: >-
       QueryProposersResponse is response type for the Query/Proposers RPC
       method.

--- a/go.mod
+++ b/go.mod
@@ -198,6 +198,6 @@ retract (
 	v0.43.0
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/go.mod
+++ b/go.mod
@@ -198,6 +198,6 @@ retract (
 	v0.43.0
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1 h1:0zH/uHX3et5dvqwBz/RQpXV6KvpKCrqz8gek2SQe2GA=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf h1:vXv/PaoaX7rliUZc+lNQImTGgVqJd5E/+oBmiiFuZ2c=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -219,6 +219,6 @@ replace (
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/simapp/go.mod
+++ b/simapp/go.mod
@@ -219,6 +219,6 @@ replace (
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -410,8 +410,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf h1:vXv/PaoaX7rliUZc+lNQImTGgVqJd5E/+oBmiiFuZ2c=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/simapp/go.sum
+++ b/simapp/go.sum
@@ -410,8 +410,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1 h1:0zH/uHX3et5dvqwBz/RQpXV6KvpKCrqz8gek2SQe2GA=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/simapp/test_helpers.go
+++ b/simapp/test_helpers.go
@@ -60,7 +60,7 @@ func NewSimappWithCustomOptions(t *testing.T, isCheckTx bool, options SetupOptio
 	pubKey, err := privVal.GetPubKey()
 	require.NoError(t, err)
 	// create validator set with single validator
-	validator := cmttypes.NewValidator(pubKey, 1, true)
+	validator := cmttypes.NewValidator(pubKey, 1, false)
 	valSet := cmttypes.NewValidatorSet([]*cmttypes.Validator{validator})
 
 	// generate genesis account
@@ -102,7 +102,7 @@ func Setup(t *testing.T, isCheckTx bool) *SimApp {
 	require.NoError(t, err)
 
 	// create validator set with single validator
-	validator := cmttypes.NewValidator(pubKey, 1, true)
+	validator := cmttypes.NewValidator(pubKey, 1, false)
 	valSet := cmttypes.NewValidatorSet([]*cmttypes.Validator{validator})
 
 	// generate genesis account
@@ -162,7 +162,7 @@ func GenesisStateWithSingleValidator(t *testing.T, app *SimApp) GenesisState {
 	require.NoError(t, err)
 
 	// create validator set with single validator
-	validator := cmttypes.NewValidator(pubKey, 1, true)
+	validator := cmttypes.NewValidator(pubKey, 1, false)
 	valSet := cmttypes.NewValidatorSet([]*cmttypes.Validator{validator})
 
 	// generate genesis account

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -216,6 +216,6 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -216,6 +216,6 @@ replace (
 	github.com/gin-gonic/gin => github.com/gin-gonic/gin v1.9.1
 )
 
-replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d
+replace github.com/cometbft/cometbft => github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf
 
 replace cosmossdk.io/store => github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -404,8 +404,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf h1:vXv/PaoaX7rliUZc+lNQImTGgVqJd5E/+oBmiiFuZ2c=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250807031327-f63a6917efaf/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -404,8 +404,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvsekhvalnov/jose2go v1.6.0 h1:Y9gnSnP4qEI0+/uQkHvFXeD2PLPJeXEL+ySMEA2EjTY=
 github.com/dvsekhvalnov/jose2go v1.6.0/go.mod h1:QsHjhyTlD/lAVqn/NSbVZmSCGeDehTB/mPZadG+mhXU=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1 h1:0zH/uHX3et5dvqwBz/RQpXV6KvpKCrqz8gek2SQe2GA=
-github.com/dydxprotocol/cometbft v0.38.6-0.20250805203801-49864fd76ba1/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d h1:/zByifT+6mJcShhwOqBc0olJzTPsN01Vo4dGC6f3EKs=
+github.com/dydxprotocol/cometbft v0.38.6-0.20250806205410-0272ad666e4d/go.mod h1:XSQX1hQbr54qaJb4/5YNNZGXkAQHHa6bi/KMcN1SQ7w=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018 h1:Dn08pzQTajFp1GHaZFd0istbjl793PaT50vfj4mVKNs=
 github.com/dydxprotocol/cosmos-sdk/store v1.0.3-0.20240326190927-d35618165018/go.mod h1:zMcD3hfNwd0WMTpdRUhS3QxoCoEtBXWeoKsu3iaLBbQ=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/tests/integration/staking/keeper/genesis_test.go
+++ b/tests/integration/staking/keeper/genesis_test.go
@@ -127,7 +127,7 @@ func TestInitGenesis(t *testing.T) {
 	abcivals := make([]abci.ValidatorUpdate, len(vals))
 
 	for i, val := range validators {
-		abcivals[i] = val.ABCIValidatorUpdate((f.stakingKeeper.PowerReduction(f.sdkCtx)), true)
+		abcivals[i] = val.ABCIValidatorUpdate((f.stakingKeeper.PowerReduction(f.sdkCtx)), false)
 	}
 
 	assert.DeepEqual(t, abcivals, vals)
@@ -294,7 +294,7 @@ func TestInitGenesisLargeValidatorSet(t *testing.T) {
 
 	abcivals := make([]abci.ValidatorUpdate, 100)
 	for i, val := range validators[:100] {
-		abcivals[i] = val.ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true)
+		abcivals[i] = val.ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false)
 	}
 
 	// remove genesis validator

--- a/tests/integration/staking/keeper/validator_test.go
+++ b/tests/integration/staking/keeper/validator_test.go
@@ -556,8 +556,8 @@ func TestApplyAndReturnValidatorSetUpdatesAllNone(t *testing.T) {
 	assert.NilError(t, err)
 	validators[0], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val0bz)
 	validators[1], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val1bz)
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[1])
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[1])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesIdentical(t *testing.T) {
@@ -606,7 +606,7 @@ func TestApplyAndReturnValidatorSetUpdatesSingleValueChange(t *testing.T) {
 	validators[0] = keeper.TestingUpdateValidator(f.stakingKeeper, f.sdkCtx, validators[0], false)
 
 	updates := applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 1)
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesMultipleValueChange(t *testing.T) {
@@ -628,8 +628,8 @@ func TestApplyAndReturnValidatorSetUpdatesMultipleValueChange(t *testing.T) {
 	validators[1] = keeper.TestingUpdateValidator(f.stakingKeeper, f.sdkCtx, validators[1], false)
 
 	updates := applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 2)
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[1])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[1])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
@@ -648,7 +648,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	val2bz, err := f.stakingKeeper.ValidatorAddressCodec().StringToBytes(validators[2].GetOperator())
 	assert.NilError(t, err)
 	validators[2], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val2bz)
-	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 
 	// test validtor added at the beginning
 	//  tendermintUpdate set: {} -> {c0}
@@ -658,7 +658,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	val3bz, err := f.stakingKeeper.ValidatorAddressCodec().StringToBytes(validators[3].GetOperator())
 	assert.NilError(t, err)
 	validators[3], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val3bz)
-	assert.DeepEqual(t, validators[3].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[3].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 
 	// test validtor added at the end
 	//  tendermintUpdate set: {} -> {c0}
@@ -668,7 +668,7 @@ func TestApplyAndReturnValidatorSetUpdatesInserted(t *testing.T) {
 	val4bz, err := f.stakingKeeper.ValidatorAddressCodec().StringToBytes(validators[4].GetOperator())
 	assert.NilError(t, err)
 	validators[4], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val4bz)
-	assert.DeepEqual(t, validators[4].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[4].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesWithCliffValidator(t *testing.T) {
@@ -705,8 +705,8 @@ func TestApplyAndReturnValidatorSetUpdatesWithCliffValidator(t *testing.T) {
 	val2bz, err := f.stakingKeeper.ValidatorAddressCodec().StringToBytes(validators[2].GetOperator())
 	assert.NilError(t, err)
 	validators[2], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val2bz)
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdateZero(true), updates[1])
-	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdateZero(false), updates[1])
+	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
@@ -742,8 +742,8 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 	assert.NilError(t, err)
 	validators[0], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val0bz)
 	validators[1], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val1bz)
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[1])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[1])
 
 	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 0)
 
@@ -790,9 +790,9 @@ func TestApplyAndReturnValidatorSetUpdatesNewValidator(t *testing.T) {
 	validator, _ = f.stakingKeeper.GetValidator(f.sdkCtx, valbz)
 	validators[0], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val0bz)
 	validators[1], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val1bz)
-	assert.DeepEqual(t, validator.ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
-	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[1])
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[2])
+	assert.DeepEqual(t, validator.ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
+	assert.DeepEqual(t, validators[0].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[1])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[2])
 }
 
 func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
@@ -827,8 +827,8 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 	assert.NilError(t, err)
 	validators[2], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val2bz)
 	validators[1], _ = f.stakingKeeper.GetValidator(f.sdkCtx, val1bz)
-	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[1])
+	assert.DeepEqual(t, validators[2].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[1])
 
 	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 0)
 
@@ -870,12 +870,12 @@ func TestApplyAndReturnValidatorSetUpdatesBondTransition(t *testing.T) {
 
 	// verify initial CometBFT updates are correct
 	updates = applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 1)
-	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), true), updates[0])
+	assert.DeepEqual(t, validators[1].ABCIValidatorUpdate(f.stakingKeeper.PowerReduction(f.sdkCtx), false), updates[0])
 
 	applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 0)
 }
 
-func TestProposerSetCanProposeField(t *testing.T) {
+func TestProposerSet(t *testing.T) {
 	f, addrs, _ := bootstrapValidatorTest(t, 1000, 10)
 
 	// Create 6 validators (need at least 5 bonded for proposer set)
@@ -894,7 +894,7 @@ func TestProposerSetCanProposeField(t *testing.T) {
 	updates := applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 6)
 
 	for _, update := range updates {
-		assert.Equal(t, true, update.CanPropose, "When no proposer set is defined, all validators should have CanPropose = true")
+		assert.Equal(t, false, update.ProposeDisabled, "When no proposer set is defined, all validators should have ProposeDisabled=false")
 	}
 
 	// Set first 5 as proposers
@@ -933,19 +933,17 @@ func TestProposerSetCanProposeField(t *testing.T) {
 		}
 
 		assert.Assert(t, val != nil)
-
-		expectedCanPropose := proposerAddrsSet[val.GetOperator()]
-		assert.Equal(t, expectedCanPropose, update.CanPropose)
+		assert.Equal(t, !proposerAddrsSet[val.GetOperator()], update.ProposeDisabled)
 	}
 
-	// Set to proposers to empty and all validators should default to being able to propose
+	// Set to proposers to empty and all validators should be able to propose again
 	err = f.stakingKeeper.SetProposers(f.sdkCtx, []string{})
 	assert.NilError(t, err)
 
 	updates = applyValidatorSetUpdates(t, f.sdkCtx, f.stakingKeeper, 6)
 
 	for _, update := range updates {
-		assert.Equal(t, true, update.CanPropose)
+		assert.Equal(t, false, update.ProposeDisabled)
 	}
 }
 

--- a/testutil/sims/app_helpers.go
+++ b/testutil/sims/app_helpers.go
@@ -59,7 +59,7 @@ func CreateRandomValidatorSet() (*cmttypes.ValidatorSet, error) {
 	}
 
 	// create validator set with single validator
-	validator := cmttypes.NewValidator(pubKey, 1, true)
+	validator := cmttypes.NewValidator(pubKey, 1, false)
 
 	return cmttypes.NewValidatorSet([]*cmttypes.Validator{validator}), nil
 }

--- a/types/module/module.go
+++ b/types/module/module.go
@@ -814,9 +814,9 @@ func (m *Manager) EndBlock(ctx sdk.Context) (sdk.EndBlock, error) {
 
 				for _, updates := range moduleValUpdates {
 					validatorUpdates = append(validatorUpdates, abci.ValidatorUpdate{
-						PubKey:     updates.PubKey,
-						Power:      updates.Power,
-						CanPropose: updates.CanPropose,
+						PubKey:          updates.PubKey,
+						Power:           updates.Power,
+						ProposeDisabled: updates.ProposeDisabled,
 					})
 				}
 			}

--- a/x/slashing/simulation/operations_test.go
+++ b/x/slashing/simulation/operations_test.go
@@ -71,7 +71,7 @@ func (suite *SimTestSuite) SetupTest() {
 			return nil, fmt.Errorf("failed to create pubkey: %w", err)
 		}
 
-		validator := cmttypes.NewValidator(cmtPk, 1, true)
+		validator := cmttypes.NewValidator(cmtPk, 1, false)
 
 		return cmttypes.NewValidatorSet([]*cmttypes.Validator{validator}), nil
 	}

--- a/x/staking/keeper/genesis.go
+++ b/x/staking/keeper/genesis.go
@@ -205,8 +205,8 @@ func (k Keeper) InitGenesis(ctx context.Context, data *types.GenesisState) (res 
 				panic(fmt.Sprintf("validator %s not found", lv.Address))
 			}
 
-			canPropose := len(data.Proposers) == 0 || proposerMap[validator.OperatorAddress]
-			update := validator.ABCIValidatorUpdate(k.PowerReduction(ctx), canPropose)
+			proposeDisabled := len(data.Proposers) > 0 && !proposerMap[validator.OperatorAddress]
+			update := validator.ABCIValidatorUpdate(k.PowerReduction(ctx), proposeDisabled)
 			update.Power = lv.Power // keep the next-val-set offset, use the last power for the first block
 			res = append(res, update)
 		}

--- a/x/staking/keeper/val_state_change.go
+++ b/x/staking/keeper/val_state_change.go
@@ -151,7 +151,9 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		return nil, err
 	}
 
-	// Get proposers to properly set `CanPropose` of validator updates
+	// Get proposers to properly set `ProposeDisabled` of validator updates
+	// Propose is disabled for a validator `v` if proposer set isn't empty
+	// and `v` doesn't exist in proposer set
 	proposers, err := k.GetProposers(ctx)
 	if err != nil {
 		return nil, err
@@ -162,8 +164,8 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		proposerMap[proposer] = true
 	}
 
-	canPropose := func(validatorOpAddr string) bool {
-		return len(proposers) == 0 || proposerMap[validatorOpAddr]
+	proposeDisabled := func(validatorOpAddr string) bool {
+		return len(proposers) > 0 && !proposerMap[validatorOpAddr]
 	}
 
 	var updatedProposers []string // for sanity check later
@@ -222,11 +224,11 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 
 		// update the validator set if power has changed or if a full proposer set update is needed
 		if !found || !bytes.Equal(oldPowerBytes, newPowerBytes) || sendFullProposerSetUpdate {
-			cp := canPropose(validator.GetOperator())
-			update := validator.ABCIValidatorUpdate(powerReduction, cp)
+			pd := proposeDisabled(validator.GetOperator())
+			update := validator.ABCIValidatorUpdate(powerReduction, pd)
 			updates = append(updates, update)
 
-			if cp {
+			if !pd {
 				updatedProposers = append(updatedProposers, validator.GetOperator())
 			}
 
@@ -261,11 +263,11 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 			return nil, err
 		}
 
-		cp := canPropose(validator.GetOperator())
-		update := validator.ABCIValidatorUpdateZero(cp)
+		pd := proposeDisabled(validator.GetOperator())
+		update := validator.ABCIValidatorUpdateZero(pd)
 		updates = append(updates, update)
 
-		if cp {
+		if !pd {
 			updatedProposers = append(updatedProposers, validator.GetOperator())
 		}
 	}
@@ -275,13 +277,13 @@ func (k Keeper) ApplyAndReturnValidatorSetUpdates(ctx context.Context) (updates 
 		if err := k.checkProposerSetInvariants(ctx, updatedProposers); err != nil {
 			// Log error and default to every validator can propose
 			sdk.UnwrapSDKContext(ctx).Logger().Error(
-				"Proposer set sanity check failed, defaulting all validators to CanPropose=true",
+				"Proposer set sanity check failed, defaulting all validators to ProposeDisabled=false",
 				"error",
 				err,
 			)
 
 			for i := range updates {
-				updates[i].CanPropose = true
+				updates[i].ProposeDisabled = false
 			}
 		}
 

--- a/x/staking/keeper/val_state_change_test.go
+++ b/x/staking/keeper/val_state_change_test.go
@@ -57,7 +57,7 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_ProposerSet() {
 		verify func(updates []abci.ValidatorUpdate)
 	}{
 		{
-			name: "proposers not set, validator power change, CanPropose should default to true",
+			name: "proposers not set, validator power change, ProposeDisabled should default to false",
 			setup: func(testCtx sdk.Context) error {
 				setupValidators(testCtx, 1)
 
@@ -74,12 +74,12 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_ProposerSet() {
 			},
 			verify: func(updates []abci.ValidatorUpdate) {
 				require.Len(updates, 1)
-				require.True(updates[0].CanPropose)
+				require.False(updates[0].ProposeDisabled)
 				require.Equal(int64(1001), updates[0].Power) // 1000 + 1
 			},
 		},
 		{
-			name: "proposers set to empty, validator power change, CanPropose should default to true",
+			name: "proposers set to empty, validator power change, ProposeDisabled should default to false",
 			setup: func(testCtx sdk.Context) error {
 				setupValidators(testCtx, 1)
 
@@ -100,7 +100,7 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_ProposerSet() {
 			},
 			verify: func(updates []abci.ValidatorUpdate) {
 				require.Len(updates, 1)
-				require.True(updates[0].CanPropose)
+				require.False(updates[0].ProposeDisabled)
 				require.Equal(int64(1001), updates[0].Power) // 1000 + 1
 			},
 		},
@@ -116,7 +116,7 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_ProposerSet() {
 				require.Len(updates, 5)
 
 				for _, update := range updates {
-					require.True(update.CanPropose)
+					require.False(update.ProposeDisabled)
 					require.Equal(int64(1000), update.Power)
 				}
 			},
@@ -158,11 +158,11 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdates_ProposerSet() {
 					valUpdate, exists := getUpdateByPK(updates, PKs[i])
 					require.True(exists)
 
-					// Check `CanPropose`
+					// Check `ProposeDisabled`
 					if i < 5 {
-						require.True(valUpdate.CanPropose)
+						require.False(valUpdate.ProposeDisabled)
 					} else {
-						require.False(valUpdate.CanPropose)
+						require.True(valUpdate.ProposeDisabled)
 					}
 
 					// Check `Power`

--- a/x/staking/keeper/validator_test.go
+++ b/x/staking/keeper/validator_test.go
@@ -46,7 +46,7 @@ func (s *KeeperTestSuite) TestValidator() {
 	updates := s.applyValidatorSetUpdates(ctx, keeper, 1)
 	validator, err := keeper.GetValidator(ctx, valAddr)
 	require.NoError(err)
-	require.Equal(validator.ABCIValidatorUpdate(keeper.PowerReduction(ctx), true), updates[0])
+	require.Equal(validator.ABCIValidatorUpdate(keeper.PowerReduction(ctx), false), updates[0])
 
 	// after the save the validator should be bonded
 	require.Equal(stakingtypes.Bonded, validator.Status)
@@ -274,8 +274,8 @@ func (s *KeeperTestSuite) TestApplyAndReturnValidatorSetUpdatesPowerDecrease() {
 
 	// CometBFT updates should reflect power change
 	updates := s.applyValidatorSetUpdates(ctx, keeper, 2)
-	require.Equal(validators[0].ABCIValidatorUpdate(keeper.PowerReduction(ctx), true), updates[0])
-	require.Equal(validators[1].ABCIValidatorUpdate(keeper.PowerReduction(ctx), true), updates[1])
+	require.Equal(validators[0].ABCIValidatorUpdate(keeper.PowerReduction(ctx), false), updates[0])
+	require.Equal(validators[1].ABCIValidatorUpdate(keeper.PowerReduction(ctx), false), updates[1])
 }
 
 func (s *KeeperTestSuite) TestUpdateValidatorCommission() {

--- a/x/staking/simulation/operations_test.go
+++ b/x/staking/simulation/operations_test.go
@@ -72,7 +72,7 @@ func (s *SimTestSuite) SetupTest() {
 	account := accounts[0]
 	cmtPk, err := cryptocodec.ToCmtPubKeyInterface(account.PubKey)
 	require.NoError(s.T(), err)
-	validator := cmttypes.NewValidator(cmtPk, 1, true)
+	validator := cmttypes.NewValidator(cmtPk, 1, false)
 
 	startupCfg := simtestutil.DefaultStartUpConfig()
 	startupCfg.GenesisAccounts = accs

--- a/x/staking/testutil/cmt.go
+++ b/x/staking/testutil/cmt.go
@@ -27,7 +27,7 @@ func ToCmtValidator(v types.Validator, r math.Int) (*cmttypes.Validator, error) 
 		return nil, err
 	}
 
-	return cmttypes.NewValidator(tmPk, v.ConsensusPower(r), true), nil
+	return cmttypes.NewValidator(tmPk, v.ConsensusPower(r), false), nil
 }
 
 // ToCmtValidators casts all validators to the corresponding CometBFT type.

--- a/x/staking/types/query.pb.go
+++ b/x/staking/types/query.pb.go
@@ -1430,7 +1430,7 @@ var xxx_messageInfo_QueryProposersRequest proto.InternalMessageInfo
 
 // QueryProposersResponse is response type for the Query/Proposers RPC method.
 type QueryProposersResponse struct {
-	// proposers contains the list of validator operator addresses eligible to propose blocks.
+	// proposers is the list of operator addresses of validators eligible to propose blocks.
 	Proposers []string `protobuf:"bytes,1,rep,name=proposers,proto3" json:"proposers,omitempty"`
 }
 
@@ -1671,7 +1671,7 @@ type QueryClient interface {
 	Pool(ctx context.Context, in *QueryPoolRequest, opts ...grpc.CallOption) (*QueryPoolResponse, error)
 	// Parameters queries the staking parameters.
 	Params(ctx context.Context, in *QueryParamsRequest, opts ...grpc.CallOption) (*QueryParamsResponse, error)
-	// Proposers queries the current set of validators eligible to propose blocks.
+	// Proposers queries the set of validators eligible to propose blocks.
 	Proposers(ctx context.Context, in *QueryProposersRequest, opts ...grpc.CallOption) (*QueryProposersResponse, error)
 }
 
@@ -1873,7 +1873,7 @@ type QueryServer interface {
 	Pool(context.Context, *QueryPoolRequest) (*QueryPoolResponse, error)
 	// Parameters queries the staking parameters.
 	Params(context.Context, *QueryParamsRequest) (*QueryParamsResponse, error)
-	// Proposers queries the current set of validators eligible to propose blocks.
+	// Proposers queries the set of validators eligible to propose blocks.
 	Proposers(context.Context, *QueryProposersRequest) (*QueryProposersResponse, error)
 }
 

--- a/x/staking/types/validator.go
+++ b/x/staking/types/validator.go
@@ -258,31 +258,31 @@ func (d Description) EnsureLength() (Description, error) {
 
 // ABCIValidatorUpdate returns an abci.ValidatorUpdate from a staking validator type
 // with the full validator power
-func (v Validator) ABCIValidatorUpdate(r math.Int, canPropose bool) abci.ValidatorUpdate {
+func (v Validator) ABCIValidatorUpdate(r math.Int, proposeDisabled bool) abci.ValidatorUpdate {
 	tmProtoPk, err := v.TmConsPublicKey()
 	if err != nil {
 		panic(err)
 	}
 
 	return abci.ValidatorUpdate{
-		PubKey:     tmProtoPk,
-		Power:      v.ConsensusPower(r),
-		CanPropose: canPropose,
+		PubKey:          tmProtoPk,
+		Power:           v.ConsensusPower(r),
+		ProposeDisabled: proposeDisabled,
 	}
 }
 
 // ABCIValidatorUpdateZero returns an abci.ValidatorUpdate from a staking validator type
 // with zero power used for validator updates.
-func (v Validator) ABCIValidatorUpdateZero(canPropose bool) abci.ValidatorUpdate {
+func (v Validator) ABCIValidatorUpdateZero(proposeDisabled bool) abci.ValidatorUpdate {
 	tmProtoPk, err := v.TmConsPublicKey()
 	if err != nil {
 		panic(err)
 	}
 
 	return abci.ValidatorUpdate{
-		PubKey:     tmProtoPk,
-		Power:      0,
-		CanPropose: canPropose,
+		PubKey:          tmProtoPk,
+		Power:           0,
+		ProposeDisabled: proposeDisabled,
 	}
 }
 

--- a/x/staking/types/validator_test.go
+++ b/x/staking/types/validator_test.go
@@ -66,7 +66,7 @@ func TestABCIValidatorUpdate(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pk, abciVal.PubKey)
 	require.Equal(t, validator.BondedTokens().Int64(), abciVal.Power)
-	require.True(t, abciVal.CanPropose)
+	require.True(t, abciVal.ProposeDisabled)
 }
 
 func TestABCIValidatorUpdateZero(t *testing.T) {
@@ -76,7 +76,7 @@ func TestABCIValidatorUpdateZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, pk, abciVal.PubKey)
 	require.Equal(t, int64(0), abciVal.Power)
-	require.False(t, abciVal.CanPropose)
+	require.False(t, abciVal.ProposeDisabled)
 }
 
 func TestShareTokens(t *testing.T) {
@@ -318,7 +318,7 @@ func TestValidatorToCmt(t *testing.T) {
 		vals.Validators = append(vals.Validators, val)
 		cmtPk, err := cryptocodec.ToCmtPubKeyInterface(pk)
 		require.NoError(t, err)
-		expected[i] = cmttypes.NewValidator(cmtPk, val.ConsensusPower(sdk.DefaultPowerReduction), true)
+		expected[i] = cmttypes.NewValidator(cmtPk, val.ConsensusPower(sdk.DefaultPowerReduction), false)
 	}
 	vs, err := testutil.ToCmtValidators(vals, sdk.DefaultPowerReduction)
 	require.NoError(t, err)


### PR DESCRIPTION


<!--
The default pull request template is for types feat, fix, or refactor.
For other templates, add one of the following parameters to the url:
- template=docs.md
- template=other.md
-->

## Description

For backward compatibility, `CanPropose` is replaced by `ProposeDisabled` in validator abci updates (see [PR on cometbft](https://github.com/dydxprotocol/cometbft/pull/48))